### PR TITLE
#34/feat(user) : 워크스페이스 구독 API와 구독 스키마 정비

### DIFF
--- a/http/workspaces.http
+++ b/http/workspaces.http
@@ -1,0 +1,75 @@
+@baseUrl = http://localhost:3000
+# 액세스 토큰을 입력하세요
+@accessToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbWxyb2IzZW4wMDAwZ2RheXNzaHY0ZTFxIiwiYWNjb3VudElkIjoiY21scm9iM2VuMDAwMWdkYXl2OGtmYTM1MSIsInBsYXRmb3JtIjoiV0VCIiwiaWF0IjoxNzcxMzk3NDU0LCJleHAiOjE3NzEzOTgzNTQsImF1ZCI6ImFwaSIsImlzcyI6ImVhc3ktY2xpcCJ9.SIdlhVjqDe0qTqpCn-7KAI9uFWh4mh3aNqMdRoeHxpo
+
+
+############################################################
+# Workspace Subscription API Test (#34)
+# - GET /workspaces/me/subscription
+# - PATCH /workspaces/me/subscription
+############################################################
+
+### 1) 내 워크스페이스 구독 상태 조회
+GET {{baseUrl}}/workspaces/me/subscription
+Authorization: Bearer {{accessToken}}
+
+### 2) PRO 업그레이드 (CHANGE_PLAN)
+PATCH {{baseUrl}}/workspaces/me/subscription
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "type": "CHANGE_PLAN",
+  "plan": "PRO"
+}
+
+### 3) 해지 예약 (CANCEL)
+# 조건: 현재 상태가 PRO + ACTIVE 여야 함
+PATCH {{baseUrl}}/workspaces/me/subscription
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "type": "CANCEL"
+}
+
+### 4) 해지 예약 취소/재개 (RESUME)
+# 조건: 현재 상태가 PRO + CANCELED 여야 함
+PATCH {{baseUrl}}/workspaces/me/subscription
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "type": "RESUME"
+}
+
+### 5) FREE로 변경 (CHANGE_PLAN)
+PATCH {{baseUrl}}/workspaces/me/subscription
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "type": "CHANGE_PLAN",
+  "plan": "FREE"
+}
+
+### 6) 잘못된 요청 예시 (BAD_REQUEST)
+# CANCEL/RESUME 요청에는 plan을 보내면 안 됨
+PATCH {{baseUrl}}/workspaces/me/subscription
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "type": "CANCEL",
+  "plan": "PRO"
+}
+
+### 7) 충돌 요청 예시 (CONFLICT)
+# FREE 상태에서 CANCEL 요청
+PATCH {{baseUrl}}/workspaces/me/subscription
+Authorization: Bearer {{accessToken}}
+Content-Type: application/json
+
+{
+  "type": "CANCEL"
+}

--- a/prisma/migrations/20260218070000_update_subscription_model/migration.sql
+++ b/prisma/migrations/20260218070000_update_subscription_model/migration.sql
@@ -1,0 +1,68 @@
+-- SubscriptionPlan: PRO|TEAM -> FREE|PRO
+BEGIN;
+CREATE TYPE "SubscriptionPlan_new" AS ENUM ('FREE', 'PRO');
+ALTER TABLE "Subscription" ALTER COLUMN "plan" DROP DEFAULT;
+ALTER TABLE "Subscription"
+ALTER COLUMN "plan" TYPE "SubscriptionPlan_new"
+USING (
+  CASE
+    WHEN "plan"::text = 'TEAM' THEN 'PRO'
+    ELSE "plan"::text
+  END::"SubscriptionPlan_new"
+);
+ALTER TYPE "SubscriptionPlan" RENAME TO "SubscriptionPlan_old";
+ALTER TYPE "SubscriptionPlan_new" RENAME TO "SubscriptionPlan";
+DROP TYPE "SubscriptionPlan_old";
+COMMIT;
+
+-- SubscriptionStatus: ACTIVE|CANCELED|PAST_DUE -> ACTIVE|CANCELED|EXPIRED
+BEGIN;
+CREATE TYPE "SubscriptionStatus_new" AS ENUM ('ACTIVE', 'CANCELED', 'EXPIRED');
+ALTER TABLE "Subscription" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Subscription"
+ALTER COLUMN "status" TYPE "SubscriptionStatus_new"
+USING (
+  CASE
+    WHEN "status"::text = 'PAST_DUE' THEN 'EXPIRED'
+    ELSE "status"::text
+  END::"SubscriptionStatus_new"
+);
+ALTER TYPE "SubscriptionStatus" RENAME TO "SubscriptionStatus_old";
+ALTER TYPE "SubscriptionStatus_new" RENAME TO "SubscriptionStatus";
+DROP TYPE "SubscriptionStatus_old";
+COMMIT;
+
+ALTER TABLE "Subscription" RENAME COLUMN "expiresAt" TO "currentPeriodEnd";
+ALTER TABLE "Subscription" ADD COLUMN "autoRenew" BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE "Subscription" ALTER COLUMN "plan" SET DEFAULT 'FREE';
+ALTER TABLE "Subscription" ALTER COLUMN "status" SET DEFAULT 'ACTIVE';
+
+UPDATE "Subscription"
+SET "autoRenew" = CASE
+  WHEN "plan" = 'PRO' AND "status" = 'ACTIVE' THEN true
+  ELSE false
+END;
+
+-- Personal workspace는 subscription row를 항상 가지도록 백필
+INSERT INTO "Subscription" (
+  "id",
+  "plan",
+  "status",
+  "autoRenew",
+  "startedAt",
+  "currentPeriodEnd",
+  "workspaceId"
+)
+SELECT
+  concat('sub_', md5(random()::text || clock_timestamp()::text || w."id")),
+  'FREE'::"SubscriptionPlan",
+  'ACTIVE'::"SubscriptionStatus",
+  false,
+  NOW(),
+  NULL,
+  w."id"
+FROM "Workspace" w
+LEFT JOIN "Subscription" s ON s."workspaceId" = w."id"
+WHERE w."type" = 'PERSONAL'
+  AND s."id" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,15 +22,15 @@ enum Theme {
 
 // 구독 플랜
 enum SubscriptionPlan {
+  FREE
   PRO
-  TEAM
 }
 
 // 구독 상태
 enum SubscriptionStatus {
   ACTIVE
   CANCELED
-  PAST_DUE
+  EXPIRED
 }
 
 enum WorkspaceType {
@@ -160,12 +160,13 @@ model UserSettings {
 
 model Subscription {
   id        String             @id @default(cuid())
-  // 구독 row가 없으면 무료로 간주한다.
-  plan      SubscriptionPlan
+  // 개인 워크스페이스는 구독 row를 항상 가진다.
+  plan      SubscriptionPlan   @default(FREE)
   status    SubscriptionStatus @default(ACTIVE)
+  autoRenew Boolean            @default(false)
 
   startedAt DateTime @default(now())
-  expiresAt DateTime?
+  currentPeriodEnd DateTime?
 
   workspaceId String @unique
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { ConfigModule } from '@nestjs/config';
 import { FoldersModule } from './folders/folders.module';
 import { ClipsModule } from './clips/clips.module';
+import { WorkspacesModule } from './workspaces/workspaces.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { ClipsModule } from './clips/clips.module';
     UsersModule,
     FoldersModule,
     ClipsModule,
+    WorkspacesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/infrastructure/prisma-auth.repository.ts
+++ b/src/auth/infrastructure/prisma-auth.repository.ts
@@ -1,7 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { AuthProvider as PrismaAuthProvider, Platform } from '@prisma/client';
+import {
+  AuthProvider as PrismaAuthProvider,
+  Platform,
+  SubscriptionPlan,
+  SubscriptionStatus,
+  WorkspaceRole,
+  WorkspaceType,
+} from '@prisma/client';
 import { createHash } from 'crypto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
@@ -74,27 +81,53 @@ export class PrismaAuthRepository implements AuthRepository {
   async createUserWithAuthAccount(
     input: CreateAuthAccountInput,
   ): Promise<AuthAccount> {
-    const user = await this.prisma.user.create({
-      data: {
-        authAccounts: {
-          create: {
-            provider: input.provider as PrismaAuthProvider,
-            providerUserId: input.providerUserId,
-            email: input.email,
-            displayName: this.resolveDisplayName(
-              input.displayName,
-              input.email,
-            ),
-            profileImageUrl: input.profileImageUrl ?? null,
+    const resolvedDisplayName = this.resolveDisplayName(
+      input.displayName,
+      input.email,
+    );
+
+    const account = await this.prisma.$transaction(async (tx) => {
+      const user = await tx.user.create({
+        data: {
+          authAccounts: {
+            create: {
+              provider: input.provider as PrismaAuthProvider,
+              providerUserId: input.providerUserId,
+              email: input.email,
+              displayName: resolvedDisplayName,
+              profileImageUrl: input.profileImageUrl ?? null,
+            },
           },
         },
-      },
-      include: {
-        authAccounts: true,
-      },
-    });
+        include: {
+          authAccounts: true,
+        },
+      });
 
-    const account = user.authAccounts[0];
+      await tx.workspace.create({
+        data: {
+          name: 'Personal Workspace',
+          type: WorkspaceType.PERSONAL,
+          ownerUserId: user.id,
+          users: {
+            create: {
+              userId: user.id,
+              role: WorkspaceRole.OWNER,
+            },
+          },
+          subscription: {
+            create: {
+              plan: SubscriptionPlan.FREE,
+              status: SubscriptionStatus.ACTIVE,
+              autoRenew: false,
+              currentPeriodEnd: null,
+            },
+          },
+        },
+      });
+
+      return user.authAccounts[0];
+    });
 
     return this.mapAuthAccount(account);
   }

--- a/src/clips/presentation/clips.controller.ts
+++ b/src/clips/presentation/clips.controller.ts
@@ -32,6 +32,27 @@ import { ClipsError } from '../application/clips.error';
 import { RecordClipViewUseCase } from '../application/usecases/record-clip-view.usecase';
 import { ListRecentViewedClipsUseCase } from '../application/usecases/list-recent-viewed-clips.usecase';
 
+// TODO: 현재 clips 도메인이 콘텐츠 + 상호작용(Like, View, Favorite)을 모두 포함하며
+// Aggregate 경계가 흐려지고 있음.
+// → Clip(콘텐츠)과 Interaction(사용자-클립 관계)을 분리 필요.
+//
+// [분리 대상 엔드포인트]
+// 1. View 관련
+//    - POST   /clips/:id/views
+//    - GET    /clips/views/recent
+//
+// 2. Like 관련
+//    - POST   /clips/:id/likes
+//    - DELETE /clips/:id/likes
+//
+// → 위 엔드포인트는 ClipController에서 제거 후
+//   Interaction 전용 Controller로 이동.
+//
+// 목표:
+// - Clip 도메인은 콘텐츠 CRUD 및 검색만 책임
+// - Interaction 도메인은 사용자-클립 관계 데이터(Like/View/Favorite)만 책임
+// - Clip은 Interaction을 모르도록 의존성 단방향 유지
+
 @Controller('clips')
 export class ClipsController {
   constructor(

--- a/src/folders/infrastructure/prisma-folders.repository.ts
+++ b/src/folders/infrastructure/prisma-folders.repository.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { WorkspaceRole, WorkspaceType } from '@prisma/client';
+import {
+  SubscriptionPlan,
+  SubscriptionStatus,
+  WorkspaceRole,
+  WorkspaceType,
+} from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
   CreateFolderParams,
@@ -27,29 +32,45 @@ export class PrismaFoldersRepository implements FoldersRepository {
   }
 
   async getOrCreatePersonalWorkspaceId(userId: string): Promise<string> {
-    const workspace = await this.prisma.workspace.upsert({
-      where: {
-        ownerUserId_type: {
-          ownerUserId: userId,
-          type: WorkspaceType.PERSONAL,
-        },
-      },
-      update: {},
-      create: {
-        name: 'Personal Workspace',
-        type: WorkspaceType.PERSONAL,
-        ownerUserId: userId,
-        users: {
-          create: {
-            userId,
-            role: WorkspaceRole.OWNER,
+    return this.prisma.$transaction(async (tx) => {
+      const workspace = await tx.workspace.upsert({
+        where: {
+          ownerUserId_type: {
+            ownerUserId: userId,
+            type: WorkspaceType.PERSONAL,
           },
         },
-      },
-      select: { id: true },
-    });
+        update: {},
+        create: {
+          name: 'Personal Workspace',
+          type: WorkspaceType.PERSONAL,
+          ownerUserId: userId,
+          users: {
+            create: {
+              userId,
+              role: WorkspaceRole.OWNER,
+            },
+          },
+        },
+        select: { id: true },
+      });
 
-    return workspace.id;
+      await tx.subscription.upsert({
+        where: {
+          workspaceId: workspace.id,
+        },
+        update: {},
+        create: {
+          workspaceId: workspace.id,
+          plan: SubscriptionPlan.FREE,
+          status: SubscriptionStatus.ACTIVE,
+          autoRenew: false,
+          currentPeriodEnd: null,
+        },
+      });
+
+      return workspace.id;
+    });
   }
 
   async findFoldersByWorkspaceId(workspaceId: string): Promise<Folder[]> {

--- a/src/workspaces/application/policies/subscription-expiration.policy.ts
+++ b/src/workspaces/application/policies/subscription-expiration.policy.ts
@@ -1,0 +1,32 @@
+import { WorkspacesRepository } from '../../domain/workspaces.repository';
+import {
+  WorkspaceSubscription,
+  WorkspaceSubscriptionPlan,
+  WorkspaceSubscriptionStatus,
+} from '../../domain/workspace.types';
+
+export async function normalizeExpiredSubscription(
+  workspacesRepository: WorkspacesRepository,
+  subscription: WorkspaceSubscription,
+): Promise<WorkspaceSubscription> {
+  if (!isCanceledSubscriptionExpired(subscription)) {
+    return subscription;
+  }
+
+  return workspacesRepository.updateWorkspaceSubscription(subscription.id, {
+    plan: WorkspaceSubscriptionPlan.FREE,
+    status: WorkspaceSubscriptionStatus.EXPIRED,
+    autoRenew: false,
+  });
+}
+
+export function isCanceledSubscriptionExpired(
+  subscription: WorkspaceSubscription,
+): boolean {
+  return (
+    subscription.plan === WorkspaceSubscriptionPlan.PRO &&
+    subscription.status === WorkspaceSubscriptionStatus.CANCELED &&
+    subscription.currentPeriodEnd !== null &&
+    subscription.currentPeriodEnd <= new Date()
+  );
+}

--- a/src/workspaces/application/usecases/get-my-subscription.usecase.spec.ts
+++ b/src/workspaces/application/usecases/get-my-subscription.usecase.spec.ts
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { GetMySubscriptionUseCase } from './get-my-subscription.usecase';
+import { WorkspacesRepository } from '../../domain/workspaces.repository';
+import {
+  WorkspaceSubscription,
+  WorkspaceSubscriptionPlan,
+  WorkspaceSubscriptionStatus,
+} from '../../domain/workspace.types';
+
+const createRepository = (): jest.Mocked<WorkspacesRepository> => ({
+  getOrCreatePersonalWorkspaceSubscription: jest.fn(),
+  updateWorkspaceSubscription: jest.fn(),
+});
+
+const createSubscription = (
+  overrides: Partial<WorkspaceSubscription> = {},
+): WorkspaceSubscription => ({
+  id: 'subscription-id',
+  workspaceId: 'workspace-id',
+  plan: WorkspaceSubscriptionPlan.FREE,
+  status: WorkspaceSubscriptionStatus.ACTIVE,
+  autoRenew: false,
+  currentPeriodEnd: null,
+  startedAt: new Date('2026-02-01T00:00:00.000Z'),
+  ...overrides,
+});
+
+describe('GetMySubscriptionUseCase', () => {
+  it('현재 구독 상태를 반환한다', async () => {
+    const repo = createRepository();
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription(),
+    );
+
+    const usecase = new GetMySubscriptionUseCase(repo);
+    const result = await usecase.execute('user-id');
+
+    expect(repo.updateWorkspaceSubscription).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      plan: WorkspaceSubscriptionPlan.FREE,
+      status: WorkspaceSubscriptionStatus.ACTIVE,
+      autoRenew: false,
+      currentPeriodEnd: null,
+    });
+  });
+
+  it('CANCELED 구독이 만료일을 지났으면 EXPIRED로 전환해 반환한다', async () => {
+    const repo = createRepository();
+    const pastPeriodEnd = new Date('2020-01-01T00:00:00.000Z');
+
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.CANCELED,
+        autoRenew: false,
+        currentPeriodEnd: pastPeriodEnd,
+      }),
+    );
+
+    repo.updateWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.EXPIRED,
+        autoRenew: false,
+        currentPeriodEnd: pastPeriodEnd,
+      }),
+    );
+
+    const usecase = new GetMySubscriptionUseCase(repo);
+    const result = await usecase.execute('user-id');
+
+    expect(repo.updateWorkspaceSubscription).toHaveBeenCalledWith(
+      'subscription-id',
+      {
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.EXPIRED,
+        autoRenew: false,
+      },
+    );
+
+    expect(result).toEqual({
+      plan: WorkspaceSubscriptionPlan.FREE,
+      status: WorkspaceSubscriptionStatus.EXPIRED,
+      autoRenew: false,
+      currentPeriodEnd: pastPeriodEnd,
+    });
+  });
+});

--- a/src/workspaces/application/usecases/get-my-subscription.usecase.ts
+++ b/src/workspaces/application/usecases/get-my-subscription.usecase.ts
@@ -2,9 +2,8 @@ import { WorkspacesRepository } from '../../domain/workspaces.repository';
 import {
   MySubscriptionResponse,
   WorkspaceSubscription,
-  WorkspaceSubscriptionPlan,
-  WorkspaceSubscriptionStatus,
 } from '../../domain/workspace.types';
+import { normalizeExpiredSubscription } from '../policies/subscription-expiration.policy';
 
 export class GetMySubscriptionUseCase {
   constructor(private readonly workspacesRepository: WorkspacesRepository) {}
@@ -15,34 +14,12 @@ export class GetMySubscriptionUseCase {
         userId,
       );
 
-    const normalizedSubscription =
-      await this.expireIfPastPeriodEnd(currentSubscription);
+    const normalizedSubscription = await normalizeExpiredSubscription(
+      this.workspacesRepository,
+      currentSubscription,
+    );
 
     return this.toResponse(normalizedSubscription);
-  }
-
-  private async expireIfPastPeriodEnd(subscription: WorkspaceSubscription) {
-    if (!this.isCanceledSubscriptionExpired(subscription)) {
-      return subscription;
-    }
-
-    return this.workspacesRepository.updateWorkspaceSubscription(
-      subscription.id,
-      {
-        plan: WorkspaceSubscriptionPlan.FREE,
-        status: WorkspaceSubscriptionStatus.EXPIRED,
-        autoRenew: false,
-      },
-    );
-  }
-
-  private isCanceledSubscriptionExpired(subscription: WorkspaceSubscription) {
-    return (
-      subscription.plan === WorkspaceSubscriptionPlan.PRO &&
-      subscription.status === WorkspaceSubscriptionStatus.CANCELED &&
-      subscription.currentPeriodEnd !== null &&
-      subscription.currentPeriodEnd <= new Date()
-    );
   }
 
   private toResponse(

--- a/src/workspaces/application/usecases/get-my-subscription.usecase.ts
+++ b/src/workspaces/application/usecases/get-my-subscription.usecase.ts
@@ -1,0 +1,58 @@
+import { WorkspacesRepository } from '../../domain/workspaces.repository';
+import {
+  MySubscriptionResponse,
+  WorkspaceSubscription,
+  WorkspaceSubscriptionPlan,
+  WorkspaceSubscriptionStatus,
+} from '../../domain/workspace.types';
+
+export class GetMySubscriptionUseCase {
+  constructor(private readonly workspacesRepository: WorkspacesRepository) {}
+
+  async execute(userId: string): Promise<MySubscriptionResponse> {
+    const currentSubscription =
+      await this.workspacesRepository.getOrCreatePersonalWorkspaceSubscription(
+        userId,
+      );
+
+    const normalizedSubscription =
+      await this.expireIfPastPeriodEnd(currentSubscription);
+
+    return this.toResponse(normalizedSubscription);
+  }
+
+  private async expireIfPastPeriodEnd(subscription: WorkspaceSubscription) {
+    if (!this.isCanceledSubscriptionExpired(subscription)) {
+      return subscription;
+    }
+
+    return this.workspacesRepository.updateWorkspaceSubscription(
+      subscription.id,
+      {
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.EXPIRED,
+        autoRenew: false,
+      },
+    );
+  }
+
+  private isCanceledSubscriptionExpired(subscription: WorkspaceSubscription) {
+    return (
+      subscription.plan === WorkspaceSubscriptionPlan.PRO &&
+      subscription.status === WorkspaceSubscriptionStatus.CANCELED &&
+      subscription.currentPeriodEnd !== null &&
+      subscription.currentPeriodEnd <= new Date()
+    );
+  }
+
+  private toResponse(
+    subscription: WorkspaceSubscription,
+  ): MySubscriptionResponse {
+    return {
+      plan: subscription.plan,
+      status: subscription.status,
+      autoRenew: subscription.autoRenew,
+      currentPeriodEnd: subscription.currentPeriodEnd,
+    };
+  }
+}

--- a/src/workspaces/application/usecases/update-my-subscription.usecase.spec.ts
+++ b/src/workspaces/application/usecases/update-my-subscription.usecase.spec.ts
@@ -50,7 +50,7 @@ describe('UpdateMySubscriptionUseCase', () => {
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
-  it('CHANGE_PLAN PRO는 FREE에서 PRO_RENEWING 상태로 변경한다', async () => {
+  it('CHANGE_PLAN PRO는 FREE에서 ACTIVE(autoRenew=true) 상태로 변경한다', async () => {
     const repo = createRepository();
     const updatedPeriodEnd = new Date('2099-01-01T00:00:00.000Z');
 

--- a/src/workspaces/application/usecases/update-my-subscription.usecase.spec.ts
+++ b/src/workspaces/application/usecases/update-my-subscription.usecase.spec.ts
@@ -1,0 +1,285 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { UpdateMySubscriptionUseCase } from './update-my-subscription.usecase';
+import { WorkspacesRepository } from '../../domain/workspaces.repository';
+import {
+  WorkspaceSubscription,
+  WorkspaceSubscriptionAction,
+  WorkspaceSubscriptionPlan,
+  WorkspaceSubscriptionStatus,
+} from '../../domain/workspace.types';
+
+const createRepository = (): jest.Mocked<WorkspacesRepository> => ({
+  getOrCreatePersonalWorkspaceSubscription: jest.fn(),
+  updateWorkspaceSubscription: jest.fn(),
+});
+
+const createSubscription = (
+  overrides: Partial<WorkspaceSubscription> = {},
+): WorkspaceSubscription => ({
+  id: 'subscription-id',
+  workspaceId: 'workspace-id',
+  plan: WorkspaceSubscriptionPlan.FREE,
+  status: WorkspaceSubscriptionStatus.ACTIVE,
+  autoRenew: false,
+  currentPeriodEnd: null,
+  startedAt: new Date('2026-02-01T00:00:00.000Z'),
+  ...overrides,
+});
+
+describe('UpdateMySubscriptionUseCase', () => {
+  it('CHANGE_PLAN 요청에 plan이 없으면 BAD_REQUEST를 반환한다', async () => {
+    const repo = createRepository();
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        type: WorkspaceSubscriptionAction.CHANGE_PLAN,
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('CANCEL 요청에 plan을 보내면 BAD_REQUEST를 반환한다', async () => {
+    const repo = createRepository();
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        type: WorkspaceSubscriptionAction.CANCEL,
+        plan: WorkspaceSubscriptionPlan.FREE,
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('CHANGE_PLAN PRO는 FREE에서 PRO_RENEWING 상태로 변경한다', async () => {
+    const repo = createRepository();
+    const updatedPeriodEnd = new Date('2099-01-01T00:00:00.000Z');
+
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: false,
+      }),
+    );
+
+    repo.updateWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd: updatedPeriodEnd,
+      }),
+    );
+
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+    const result = await usecase.execute('user-id', {
+      type: WorkspaceSubscriptionAction.CHANGE_PLAN,
+      plan: WorkspaceSubscriptionPlan.PRO,
+    });
+
+    const updateCall = repo.updateWorkspaceSubscription.mock.calls[0];
+    expect(updateCall?.[0]).toBe('subscription-id');
+    expect(updateCall?.[1]).toMatchObject({
+      plan: WorkspaceSubscriptionPlan.PRO,
+      status: WorkspaceSubscriptionStatus.ACTIVE,
+      autoRenew: true,
+    });
+    expect(updateCall?.[1].currentPeriodEnd).toBeInstanceOf(Date);
+
+    expect(result).toEqual({
+      plan: WorkspaceSubscriptionPlan.PRO,
+      status: WorkspaceSubscriptionStatus.ACTIVE,
+      autoRenew: true,
+      currentPeriodEnd: updatedPeriodEnd,
+    });
+  });
+
+  it('CHANGE_PLAN FREE는 FREE ACTIVE 상태로 변경한다', async () => {
+    const repo = createRepository();
+
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    repo.updateWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: false,
+        currentPeriodEnd: null,
+      }),
+    );
+
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+    const result = await usecase.execute('user-id', {
+      type: WorkspaceSubscriptionAction.CHANGE_PLAN,
+      plan: WorkspaceSubscriptionPlan.FREE,
+    });
+
+    expect(repo.updateWorkspaceSubscription).toHaveBeenCalledWith(
+      'subscription-id',
+      {
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: false,
+        currentPeriodEnd: null,
+      },
+    );
+
+    expect(result).toEqual({
+      plan: WorkspaceSubscriptionPlan.FREE,
+      status: WorkspaceSubscriptionStatus.ACTIVE,
+      autoRenew: false,
+      currentPeriodEnd: null,
+    });
+  });
+
+  it('CANCEL은 PRO ACTIVE 상태에서만 수행된다', async () => {
+    const repo = createRepository();
+
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    repo.updateWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.CANCELED,
+        autoRenew: false,
+        currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+    const result = await usecase.execute('user-id', {
+      type: WorkspaceSubscriptionAction.CANCEL,
+    });
+
+    expect(repo.updateWorkspaceSubscription).toHaveBeenCalledWith(
+      'subscription-id',
+      {
+        status: WorkspaceSubscriptionStatus.CANCELED,
+        autoRenew: false,
+        currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+      },
+    );
+
+    expect(result).toEqual({
+      plan: WorkspaceSubscriptionPlan.PRO,
+      status: WorkspaceSubscriptionStatus.CANCELED,
+      autoRenew: false,
+      currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+    });
+  });
+
+  it('RESUME은 PRO CANCELED 상태에서만 수행된다', async () => {
+    const repo = createRepository();
+
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.CANCELED,
+        autoRenew: false,
+        currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    repo.updateWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+    const result = await usecase.execute('user-id', {
+      type: WorkspaceSubscriptionAction.RESUME,
+    });
+
+    expect(repo.updateWorkspaceSubscription).toHaveBeenCalledWith(
+      'subscription-id',
+      {
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+      },
+    );
+
+    expect(result).toEqual({
+      plan: WorkspaceSubscriptionPlan.PRO,
+      status: WorkspaceSubscriptionStatus.ACTIVE,
+      autoRenew: true,
+      currentPeriodEnd: new Date('2099-01-01T00:00:00.000Z'),
+    });
+  });
+
+  it('FREE 상태에서 CANCEL을 요청하면 CONFLICT를 반환한다', async () => {
+    const repo = createRepository();
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: false,
+      }),
+    );
+
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        type: WorkspaceSubscriptionAction.CANCEL,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+  });
+
+  it('만료일이 지난 CANCELED 상태에서 RESUME 요청 시 CONFLICT를 반환한다', async () => {
+    const repo = createRepository();
+
+    repo.getOrCreatePersonalWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.CANCELED,
+        autoRenew: false,
+        currentPeriodEnd: new Date('2020-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    repo.updateWorkspaceSubscription.mockResolvedValue(
+      createSubscription({
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.EXPIRED,
+        autoRenew: false,
+        currentPeriodEnd: new Date('2020-01-01T00:00:00.000Z'),
+      }),
+    );
+
+    const usecase = new UpdateMySubscriptionUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        type: WorkspaceSubscriptionAction.RESUME,
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect(repo.updateWorkspaceSubscription).toHaveBeenCalledWith(
+      'subscription-id',
+      {
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.EXPIRED,
+        autoRenew: false,
+      },
+    );
+  });
+});

--- a/src/workspaces/application/usecases/update-my-subscription.usecase.ts
+++ b/src/workspaces/application/usecases/update-my-subscription.usecase.ts
@@ -1,0 +1,215 @@
+import { WorkspacesRepository } from '../../domain/workspaces.repository';
+import {
+  MySubscriptionResponse,
+  UpdateMySubscriptionInput,
+  WorkspaceSubscription,
+  WorkspaceSubscriptionAction,
+  WorkspaceSubscriptionPlan,
+  WorkspaceSubscriptionStatus,
+} from '../../domain/workspace.types';
+import { WorkspacesError } from '../workspaces.error';
+
+const DEFAULT_PRO_BILLING_DAYS = 30;
+
+export class UpdateMySubscriptionUseCase {
+  constructor(private readonly workspacesRepository: WorkspacesRepository) {}
+
+  async execute(
+    userId: string,
+    input: UpdateMySubscriptionInput,
+  ): Promise<MySubscriptionResponse> {
+    this.validateInput(input);
+
+    const currentSubscription =
+      await this.workspacesRepository.getOrCreatePersonalWorkspaceSubscription(
+        userId,
+      );
+
+    const normalizedSubscription =
+      await this.expireIfPastPeriodEnd(currentSubscription);
+
+    switch (input.type) {
+      case WorkspaceSubscriptionAction.CHANGE_PLAN:
+        return this.changePlan(normalizedSubscription, input.plan!);
+      case WorkspaceSubscriptionAction.CANCEL:
+        return this.cancel(normalizedSubscription);
+      case WorkspaceSubscriptionAction.RESUME:
+        return this.resume(normalizedSubscription);
+      default:
+        throw new WorkspacesError(
+          'BAD_REQUEST',
+          '지원하지 않는 요청 타입입니다.',
+        );
+    }
+  }
+
+  private validateInput(input: UpdateMySubscriptionInput) {
+    if (input.type === WorkspaceSubscriptionAction.CHANGE_PLAN) {
+      if (!input.plan) {
+        throw new WorkspacesError(
+          'BAD_REQUEST',
+          'CHANGE_PLAN 요청에는 plan 값이 필요합니다.',
+        );
+      }
+
+      return;
+    }
+
+    if (input.plan !== undefined) {
+      throw new WorkspacesError(
+        'BAD_REQUEST',
+        'plan 값은 CHANGE_PLAN 요청에서만 사용할 수 있습니다.',
+      );
+    }
+  }
+
+  private async changePlan(
+    subscription: WorkspaceSubscription,
+    plan: WorkspaceSubscriptionPlan,
+  ): Promise<MySubscriptionResponse> {
+    if (plan === WorkspaceSubscriptionPlan.FREE) {
+      if (
+        subscription.plan === WorkspaceSubscriptionPlan.FREE &&
+        subscription.status === WorkspaceSubscriptionStatus.ACTIVE &&
+        !subscription.autoRenew
+      ) {
+        throw new WorkspacesError('CONFLICT', '이미 FREE 플랜입니다.');
+      }
+
+      const updated =
+        await this.workspacesRepository.updateWorkspaceSubscription(
+          subscription.id,
+          {
+            plan: WorkspaceSubscriptionPlan.FREE,
+            status: WorkspaceSubscriptionStatus.ACTIVE,
+            autoRenew: false,
+            currentPeriodEnd: null,
+          },
+        );
+
+      return this.toResponse(updated);
+    }
+
+    if (
+      subscription.plan === WorkspaceSubscriptionPlan.PRO &&
+      subscription.status === WorkspaceSubscriptionStatus.ACTIVE &&
+      subscription.autoRenew
+    ) {
+      throw new WorkspacesError('CONFLICT', '이미 PRO 플랜입니다.');
+    }
+
+    const updated = await this.workspacesRepository.updateWorkspaceSubscription(
+      subscription.id,
+      {
+        plan: WorkspaceSubscriptionPlan.PRO,
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd: this.resolveCurrentPeriodEnd(
+          subscription.currentPeriodEnd,
+        ),
+      },
+    );
+
+    return this.toResponse(updated);
+  }
+
+  private async cancel(
+    subscription: WorkspaceSubscription,
+  ): Promise<MySubscriptionResponse> {
+    if (
+      subscription.plan !== WorkspaceSubscriptionPlan.PRO ||
+      subscription.status !== WorkspaceSubscriptionStatus.ACTIVE
+    ) {
+      throw new WorkspacesError(
+        'CONFLICT',
+        'CANCEL은 PRO ACTIVE 상태에서만 가능합니다.',
+      );
+    }
+
+    const updated = await this.workspacesRepository.updateWorkspaceSubscription(
+      subscription.id,
+      {
+        status: WorkspaceSubscriptionStatus.CANCELED,
+        autoRenew: false,
+        currentPeriodEnd: this.resolveCurrentPeriodEnd(
+          subscription.currentPeriodEnd,
+        ),
+      },
+    );
+
+    return this.toResponse(updated);
+  }
+
+  private async resume(
+    subscription: WorkspaceSubscription,
+  ): Promise<MySubscriptionResponse> {
+    if (
+      subscription.plan !== WorkspaceSubscriptionPlan.PRO ||
+      subscription.status !== WorkspaceSubscriptionStatus.CANCELED
+    ) {
+      throw new WorkspacesError(
+        'CONFLICT',
+        'RESUME은 PRO CANCELED 상태에서만 가능합니다.',
+      );
+    }
+
+    const updated = await this.workspacesRepository.updateWorkspaceSubscription(
+      subscription.id,
+      {
+        status: WorkspaceSubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd: this.resolveCurrentPeriodEnd(
+          subscription.currentPeriodEnd,
+        ),
+      },
+    );
+
+    return this.toResponse(updated);
+  }
+
+  private async expireIfPastPeriodEnd(subscription: WorkspaceSubscription) {
+    if (!this.isCanceledSubscriptionExpired(subscription)) {
+      return subscription;
+    }
+
+    return this.workspacesRepository.updateWorkspaceSubscription(
+      subscription.id,
+      {
+        plan: WorkspaceSubscriptionPlan.FREE,
+        status: WorkspaceSubscriptionStatus.EXPIRED,
+        autoRenew: false,
+      },
+    );
+  }
+
+  private isCanceledSubscriptionExpired(subscription: WorkspaceSubscription) {
+    return (
+      subscription.plan === WorkspaceSubscriptionPlan.PRO &&
+      subscription.status === WorkspaceSubscriptionStatus.CANCELED &&
+      subscription.currentPeriodEnd !== null &&
+      subscription.currentPeriodEnd <= new Date()
+    );
+  }
+
+  private resolveCurrentPeriodEnd(currentPeriodEnd: Date | null): Date {
+    if (currentPeriodEnd && currentPeriodEnd > new Date()) {
+      return currentPeriodEnd;
+    }
+
+    const nextPeriodEnd = new Date();
+    nextPeriodEnd.setDate(nextPeriodEnd.getDate() + DEFAULT_PRO_BILLING_DAYS);
+
+    return nextPeriodEnd;
+  }
+
+  private toResponse(
+    subscription: WorkspaceSubscription,
+  ): MySubscriptionResponse {
+    return {
+      plan: subscription.plan,
+      status: subscription.status,
+      autoRenew: subscription.autoRenew,
+      currentPeriodEnd: subscription.currentPeriodEnd,
+    };
+  }
+}

--- a/src/workspaces/application/usecases/update-my-subscription.usecase.ts
+++ b/src/workspaces/application/usecases/update-my-subscription.usecase.ts
@@ -7,6 +7,7 @@ import {
   WorkspaceSubscriptionPlan,
   WorkspaceSubscriptionStatus,
 } from '../../domain/workspace.types';
+import { normalizeExpiredSubscription } from '../policies/subscription-expiration.policy';
 import { WorkspacesError } from '../workspaces.error';
 
 const DEFAULT_PRO_BILLING_DAYS = 30;
@@ -25,8 +26,10 @@ export class UpdateMySubscriptionUseCase {
         userId,
       );
 
-    const normalizedSubscription =
-      await this.expireIfPastPeriodEnd(currentSubscription);
+    const normalizedSubscription = await normalizeExpiredSubscription(
+      this.workspacesRepository,
+      currentSubscription,
+    );
 
     switch (input.type) {
       case WorkspaceSubscriptionAction.CHANGE_PLAN:
@@ -165,30 +168,6 @@ export class UpdateMySubscriptionUseCase {
     );
 
     return this.toResponse(updated);
-  }
-
-  private async expireIfPastPeriodEnd(subscription: WorkspaceSubscription) {
-    if (!this.isCanceledSubscriptionExpired(subscription)) {
-      return subscription;
-    }
-
-    return this.workspacesRepository.updateWorkspaceSubscription(
-      subscription.id,
-      {
-        plan: WorkspaceSubscriptionPlan.FREE,
-        status: WorkspaceSubscriptionStatus.EXPIRED,
-        autoRenew: false,
-      },
-    );
-  }
-
-  private isCanceledSubscriptionExpired(subscription: WorkspaceSubscription) {
-    return (
-      subscription.plan === WorkspaceSubscriptionPlan.PRO &&
-      subscription.status === WorkspaceSubscriptionStatus.CANCELED &&
-      subscription.currentPeriodEnd !== null &&
-      subscription.currentPeriodEnd <= new Date()
-    );
   }
 
   private resolveCurrentPeriodEnd(currentPeriodEnd: Date | null): Date {

--- a/src/workspaces/application/workspaces.error.ts
+++ b/src/workspaces/application/workspaces.error.ts
@@ -1,0 +1,15 @@
+export type WorkspacesErrorCode =
+  | 'BAD_REQUEST'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'INTERNAL';
+
+export class WorkspacesError extends Error {
+  constructor(
+    public readonly code: WorkspacesErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'WorkspacesError';
+  }
+}

--- a/src/workspaces/domain/workspace.types.ts
+++ b/src/workspaces/domain/workspace.types.ts
@@ -1,0 +1,47 @@
+export const WorkspaceSubscriptionPlan = {
+  FREE: 'FREE',
+  PRO: 'PRO',
+} as const;
+
+export type WorkspaceSubscriptionPlan =
+  (typeof WorkspaceSubscriptionPlan)[keyof typeof WorkspaceSubscriptionPlan];
+
+export const WorkspaceSubscriptionStatus = {
+  ACTIVE: 'ACTIVE',
+  CANCELED: 'CANCELED',
+  EXPIRED: 'EXPIRED',
+} as const;
+
+export type WorkspaceSubscriptionStatus =
+  (typeof WorkspaceSubscriptionStatus)[keyof typeof WorkspaceSubscriptionStatus];
+
+export const WorkspaceSubscriptionAction = {
+  CHANGE_PLAN: 'CHANGE_PLAN',
+  CANCEL: 'CANCEL',
+  RESUME: 'RESUME',
+} as const;
+
+export type WorkspaceSubscriptionAction =
+  (typeof WorkspaceSubscriptionAction)[keyof typeof WorkspaceSubscriptionAction];
+
+export type WorkspaceSubscription = {
+  id: string;
+  workspaceId: string;
+  plan: WorkspaceSubscriptionPlan;
+  status: WorkspaceSubscriptionStatus;
+  autoRenew: boolean;
+  currentPeriodEnd: Date | null;
+  startedAt: Date;
+};
+
+export type UpdateMySubscriptionInput = {
+  type: WorkspaceSubscriptionAction;
+  plan?: WorkspaceSubscriptionPlan;
+};
+
+export type MySubscriptionResponse = {
+  plan: WorkspaceSubscriptionPlan;
+  status: WorkspaceSubscriptionStatus;
+  autoRenew: boolean;
+  currentPeriodEnd: Date | null;
+};

--- a/src/workspaces/domain/workspaces.repository.ts
+++ b/src/workspaces/domain/workspaces.repository.ts
@@ -1,0 +1,25 @@
+import {
+  WorkspaceSubscription,
+  WorkspaceSubscriptionPlan,
+  WorkspaceSubscriptionStatus,
+} from './workspace.types';
+
+export const WORKSPACES_REPOSITORY = Symbol('WORKSPACES_REPOSITORY');
+
+export type UpdateWorkspaceSubscriptionParams = {
+  plan?: WorkspaceSubscriptionPlan;
+  status?: WorkspaceSubscriptionStatus;
+  autoRenew?: boolean;
+  currentPeriodEnd?: Date | null;
+};
+
+export interface WorkspacesRepository {
+  getOrCreatePersonalWorkspaceSubscription(
+    userId: string,
+  ): Promise<WorkspaceSubscription>;
+
+  updateWorkspaceSubscription(
+    subscriptionId: string,
+    params: UpdateWorkspaceSubscriptionParams,
+  ): Promise<WorkspaceSubscription>;
+}

--- a/src/workspaces/infrastructure/prisma-workspaces.repository.ts
+++ b/src/workspaces/infrastructure/prisma-workspaces.repository.ts
@@ -1,0 +1,103 @@
+import {
+  SubscriptionPlan,
+  SubscriptionStatus,
+  WorkspaceRole,
+  WorkspaceType,
+} from '@prisma/client';
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import {
+  UpdateWorkspaceSubscriptionParams,
+  WorkspacesRepository,
+} from '../domain/workspaces.repository';
+import { WorkspaceSubscription } from '../domain/workspace.types';
+
+@Injectable()
+export class PrismaWorkspacesRepository implements WorkspacesRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getOrCreatePersonalWorkspaceSubscription(
+    userId: string,
+  ): Promise<WorkspaceSubscription> {
+    return this.prisma.$transaction(async (tx) => {
+      const workspace = await tx.workspace.upsert({
+        where: {
+          ownerUserId_type: {
+            ownerUserId: userId,
+            type: WorkspaceType.PERSONAL,
+          },
+        },
+        update: {},
+        create: {
+          name: 'Personal Workspace',
+          type: WorkspaceType.PERSONAL,
+          ownerUserId: userId,
+          users: {
+            create: {
+              userId,
+              role: WorkspaceRole.OWNER,
+            },
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      const subscription = await tx.subscription.upsert({
+        where: {
+          workspaceId: workspace.id,
+        },
+        update: {},
+        create: {
+          workspaceId: workspace.id,
+          plan: SubscriptionPlan.FREE,
+          status: SubscriptionStatus.ACTIVE,
+          autoRenew: false,
+          currentPeriodEnd: null,
+        },
+        select: {
+          id: true,
+          workspaceId: true,
+          plan: true,
+          status: true,
+          autoRenew: true,
+          currentPeriodEnd: true,
+          startedAt: true,
+        },
+      });
+
+      return subscription;
+    });
+  }
+
+  async updateWorkspaceSubscription(
+    subscriptionId: string,
+    params: UpdateWorkspaceSubscriptionParams,
+  ): Promise<WorkspaceSubscription> {
+    return this.prisma.subscription.update({
+      where: {
+        id: subscriptionId,
+      },
+      data: {
+        ...(params.plan !== undefined ? { plan: params.plan } : {}),
+        ...(params.status !== undefined ? { status: params.status } : {}),
+        ...(params.autoRenew !== undefined
+          ? { autoRenew: params.autoRenew }
+          : {}),
+        ...(params.currentPeriodEnd !== undefined
+          ? { currentPeriodEnd: params.currentPeriodEnd }
+          : {}),
+      },
+      select: {
+        id: true,
+        workspaceId: true,
+        plan: true,
+        status: true,
+        autoRenew: true,
+        currentPeriodEnd: true,
+        startedAt: true,
+      },
+    });
+  }
+}

--- a/src/workspaces/presentation/dtos/update-my-subscription.dto.ts
+++ b/src/workspaces/presentation/dtos/update-my-subscription.dto.ts
@@ -1,0 +1,17 @@
+import { IsIn, IsOptional } from 'class-validator';
+import {
+  WorkspaceSubscriptionAction,
+  WorkspaceSubscriptionPlan,
+} from '../../domain/workspace.types';
+
+const SUBSCRIPTION_ACTION_VALUES = Object.values(WorkspaceSubscriptionAction);
+const SUBSCRIPTION_PLAN_VALUES = Object.values(WorkspaceSubscriptionPlan);
+
+export class UpdateMySubscriptionDto {
+  @IsIn(SUBSCRIPTION_ACTION_VALUES)
+  type: (typeof SUBSCRIPTION_ACTION_VALUES)[number];
+
+  @IsOptional()
+  @IsIn(SUBSCRIPTION_PLAN_VALUES)
+  plan?: (typeof SUBSCRIPTION_PLAN_VALUES)[number];
+}

--- a/src/workspaces/presentation/workspaces.controller.ts
+++ b/src/workspaces/presentation/workspaces.controller.ts
@@ -1,0 +1,70 @@
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  Get,
+  InternalServerErrorException,
+  NotFoundException,
+  Patch,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthContext } from 'src/auth/application/auth-context';
+import { JwtAccessGuard } from 'src/auth/presentation/guards/jwt-access-token.guard';
+import { GetMySubscriptionUseCase } from '../application/usecases/get-my-subscription.usecase';
+import { UpdateMySubscriptionUseCase } from '../application/usecases/update-my-subscription.usecase';
+import { WorkspacesError } from '../application/workspaces.error';
+import { UpdateMySubscriptionDto } from './dtos/update-my-subscription.dto';
+
+@Controller('workspaces')
+export class WorkspacesController {
+  constructor(
+    private readonly getMySubscriptionUseCase: GetMySubscriptionUseCase,
+    private readonly updateMySubscriptionUseCase: UpdateMySubscriptionUseCase,
+  ) {}
+
+  @Get('me/subscription')
+  @UseGuards(JwtAccessGuard)
+  getMySubscription(@Request() req: { user: AuthContext }) {
+    return this.run(() =>
+      this.getMySubscriptionUseCase.execute(req.user.userId),
+    );
+  }
+
+  @Patch('me/subscription')
+  @UseGuards(JwtAccessGuard)
+  updateMySubscription(
+    @Request() req: { user: AuthContext },
+    @Body() dto: UpdateMySubscriptionDto,
+  ) {
+    return this.run(() =>
+      this.updateMySubscriptionUseCase.execute(req.user.userId, dto),
+    );
+  }
+
+  private async run<T>(action: () => Promise<T>): Promise<T> {
+    try {
+      return await action();
+    } catch (error) {
+      if (error instanceof WorkspacesError) {
+        throw this.toHttpException(error);
+      }
+
+      throw error;
+    }
+  }
+
+  private toHttpException(error: WorkspacesError) {
+    switch (error.code) {
+      case 'BAD_REQUEST':
+        return new BadRequestException(error.message);
+      case 'NOT_FOUND':
+        return new NotFoundException(error.message);
+      case 'CONFLICT':
+        return new ConflictException(error.message);
+      default:
+        return new InternalServerErrorException(error.message);
+    }
+  }
+}

--- a/src/workspaces/workspaces.module.ts
+++ b/src/workspaces/workspaces.module.ts
@@ -1,0 +1,32 @@
+import { Module, Provider } from '@nestjs/common';
+import { JwtAccessGuard } from 'src/auth/presentation/guards/jwt-access-token.guard';
+import { GetMySubscriptionUseCase } from './application/usecases/get-my-subscription.usecase';
+import { UpdateMySubscriptionUseCase } from './application/usecases/update-my-subscription.usecase';
+import {
+  WORKSPACES_REPOSITORY,
+  WorkspacesRepository,
+} from './domain/workspaces.repository';
+import { PrismaWorkspacesRepository } from './infrastructure/prisma-workspaces.repository';
+import { WorkspacesController } from './presentation/workspaces.controller';
+
+const workspaceUseCases: Provider[] = [
+  { provide: WORKSPACES_REPOSITORY, useClass: PrismaWorkspacesRepository },
+  {
+    provide: GetMySubscriptionUseCase,
+    useFactory: (repo: WorkspacesRepository) =>
+      new GetMySubscriptionUseCase(repo),
+    inject: [WORKSPACES_REPOSITORY],
+  },
+  {
+    provide: UpdateMySubscriptionUseCase,
+    useFactory: (repo: WorkspacesRepository) =>
+      new UpdateMySubscriptionUseCase(repo),
+    inject: [WORKSPACES_REPOSITORY],
+  },
+];
+
+@Module({
+  controllers: [WorkspacesController],
+  providers: [...workspaceUseCases, JwtAccessGuard],
+})
+export class WorkspacesModule {}


### PR DESCRIPTION
## Description

워크스페이스 구독 API(`GET/PATCH /workspaces/me/subscription`)를 추가하고, 구독 상태 모델을 `FREE/PRO + ACTIVE/CANCELED/EXPIRED + autoRenew + currentPeriodEnd` 구조로 정비했습니다. 또한 신규 회원가입 시 개인 워크스페이스/기본 구독 row가 항상 생성되도록 반영했습니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #34, refs #34

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 코파일럿 리뷰 피드백 반영
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- Prisma 스키마 변경
- `SubscriptionPlan`: `FREE | PRO`
- `SubscriptionStatus`: `ACTIVE | CANCELED | EXPIRED`
- `autoRenew` 추가, `expiresAt`를 `currentPeriodEnd`로 전환
- 데이터 마이그레이션 추가
- `TEAM -> PRO`, `PAST_DUE -> EXPIRED` 매핑
- 개인 워크스페이스 중 구독 row 누락 데이터 백필
- Workspaces 도메인 신규 추가
- 컨트롤러: `GET/PATCH /workspaces/me/subscription`
- 유스케이스: 조회/변경(CHANGE_PLAN, CANCEL, RESUME) 및 만료 전이 처리
- 회원가입 시 개인 워크스페이스 기본 생성 보장
- `Auth` 신규 가입 트랜잭션에서 PERSONAL workspace + OWNER membership + 기본 구독 row 생성
- `Folders`의 개인 워크스페이스 생성 경로에서도 기본 구독 row 보장

## Performance/Scaling

현재 구현은 사용자 기준 PERSONAL 워크스페이스 1개를 upsert 기반으로 조회/생성하므로, 동일 사용자 재요청에서도 idempotent하게 동작합니다. 구독 row도 workspaceId unique 기반 upsert로 중복 생성을 방지합니다.

## Testing done

- `pnpm build`: 성공
- `pnpm test -- workspaces/application/usecases`: 성공
- `pnpm test -- auth/application/usecases/sign-in.usecase.spec.ts`: 성공
- `pnpm exec eslint "src/workspaces/**/*.ts" "src/folders/infrastructure/prisma-folders.repository.ts" "src/app.module.ts"`: 성공
- `pnpm exec eslint "src/auth/infrastructure/prisma-auth.repository.ts"`: 성공
- `pnpm lint`: 미실행
- `pnpm test`: 미실행
- `pnpm test:e2e`: 미실행

## Additional information

커밋은 요청하신 순서대로 3개로 분리했습니다.
1. 스키마 및 저장소 계층
2. 모듈/컨트롤러/유스케이스 핵심 구현
3. 테스트 코드 및 HTTP 시나리오
