### PR TITLE
#43/feat(setting) : Swagger 기반 OpenAPI 문서 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.4.4",
     "@prisma/client": "^6.19.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
@@ -35,7 +36,8 @@
     "passport-google-oauth20": "^2.0.0",
     "prisma": "^6.19.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.11(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)
+      '@nestjs/swagger':
+        specifier: ^11.4.4
+        version: 11.4.4(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
       '@prisma/client':
         specifier: ^6.19.1
         version: 6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)
@@ -56,6 +59,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      swagger-ui-express:
+        specifier: ^5.0.1
+        version: 5.0.1(express@5.2.1)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.2.0
@@ -682,6 +688,9 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -740,6 +749,19 @@ packages:
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
 
+  '@nestjs/mapped-types@2.1.1':
+    resolution: {integrity: sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0 || ^0.15.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
   '@nestjs/passport@11.0.5':
     resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
     peerDependencies:
@@ -756,6 +778,23 @@ packages:
     resolution: {integrity: sha512-0NfPbPlEaGwIT8/TCThxLzrlz3yzDNkfRNpbL7FiplKq3w4qXpJg0JYwqgMEJnLQZm3L/L/5XjoyfJHUO3qX9g==}
     peerDependencies:
       typescript: '>=4.8.2'
+
+  '@nestjs/swagger@11.4.4':
+    resolution: {integrity: sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0 || ^9.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@nestjs/testing@11.1.11':
     resolution: {integrity: sha512-Po2aZKXlxuySDEh3Gi05LJ7/BtfTAPRZ3KPTrbpNrTmgGr3rFgEGYpQwN50wXYw0pywoICiFLZSZ/qXsplf6NA==}
@@ -819,6 +858,9 @@ packages:
 
   '@prisma/get-platform@6.19.1':
     resolution: {integrity: sha512-zsg44QUiQAnFUyh6Fbt7c9HjMXHwFTqtrgcX7DAZmRgnkPyYT7Sh8Mn8D5PuuDYNtMOYcpLGg576MLfIORsBYw==}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sinclair/typebox@0.34.47':
     resolution: {integrity: sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==}
@@ -2371,6 +2413,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -2640,6 +2685,9 @@ packages:
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2957,6 +3005,15 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
 
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -3975,6 +4032,8 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -4051,6 +4110,14 @@ snapshots:
       '@types/jsonwebtoken': 9.0.10
       jsonwebtoken: 9.0.3
 
+  '@nestjs/mapped-types@2.1.1(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.3
+
   '@nestjs/passport@11.0.5(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
     dependencies:
       '@nestjs/common': 11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -4078,6 +4145,21 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - chokidar
+
+  '@nestjs/swagger@11.4.4(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@nestjs/common': 11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.11(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.11)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.1(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
+      js-yaml: 4.1.1
+      lodash: 4.18.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.32.6
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.3
 
   '@nestjs/testing@11.1.11(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)(@nestjs/platform-express@11.1.11)':
     dependencies:
@@ -4136,6 +4218,8 @@ snapshots:
   '@prisma/get-platform@6.19.1':
     dependencies:
       '@prisma/debug': 6.19.1
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.34.47': {}
 
@@ -5947,6 +6031,8 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
@@ -6194,6 +6280,8 @@ snapshots:
       minipass: 7.1.2
 
   path-to-regexp@8.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -6520,6 +6608,15 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  swagger-ui-dist@5.32.6:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      swagger-ui-dist: 5.32.6
 
   symbol-observable@4.0.0: {}
 

--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -8,11 +8,25 @@ import {
   UseFilters,
 } from '@nestjs/common';
 import { AuthGuard as PassportAuthGuard } from '@nestjs/passport';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { Request as ExpressRequest } from 'express';
 import { JwtAccessGuard } from 'src/common/presentation/guards/jwt-access.guard';
 import { AuthContext } from 'src/common/types/auth-context.type';
 import { ApplicationExceptionFilter } from 'src/common/presentation/filters/application-exception.filter';
 import { SwitchUserDto } from './dtos/switch-user.dto';
+import {
+  AuthSignInResponseDto,
+  LogoutResponseDto,
+  RefreshAccessTokenResponseDto,
+} from './dtos/auth-response.dto';
 import { JwtRefreshGuard } from './guards/jwt-refresh-token.guard';
 import { SignInUseCase } from '../application/usecases/sign-in.usecase';
 import { LinkAccountUseCase } from '../application/usecases/link-account.usecase';
@@ -20,6 +34,7 @@ import { SwitchUserUseCase } from '../application/usecases/switch-user.usecase';
 import { RefreshAccessTokenUseCase } from '../application/usecases/refresh-access-token.usecase';
 import { LogoutUseCase } from '../application/usecases/logout.usecase';
 import { OAuthUser } from '../domain/auth.types';
+import { ErrorResponseDto } from 'src/common/presentation/dtos/error-response.dto';
 
 interface OAuthRequest extends ExpressRequest {
   user: OAuthUser;
@@ -27,6 +42,7 @@ interface OAuthRequest extends ExpressRequest {
 
 @Controller('auth')
 @UseFilters(ApplicationExceptionFilter)
+@ApiTags('Auth')
 export class AuthController {
   constructor(
     private readonly signInUseCase: SignInUseCase,
@@ -40,32 +56,38 @@ export class AuthController {
    * Google OAuth
    * ====================================================== */
 
-  /**
-   * Google OAuth 로그인 시작
-   * GET /auth/google
-   */
   @Get('google')
   @UseGuards(PassportAuthGuard('google'))
-  googleLogin(): void {
-    // Passport가 Google 로그인 페이지로 리다이렉트
-  }
+  @ApiOperation({ summary: 'Google OAuth 로그인 시작' })
+  @ApiOkResponse({
+    description: 'OAuth 제공자 로그인 페이지로 리다이렉트됩니다.',
+  })
+  googleLogin(): void {}
 
-  /**
-   * Google OAuth 계정 연결 시작 (JWT 필요)
-   * GET /auth/google/link
-   */
   @Get('google/link')
   @UseGuards(JwtAccessGuard, PassportAuthGuard('google'))
-  googleLink(): void {
-    // JWT 인증 후 Google 로그인 페이지로 리다이렉트
-  }
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Google OAuth 계정 연결 시작' })
+  @ApiOkResponse({
+    description: '인증 후 OAuth 제공자 로그인 페이지로 리다이렉트됩니다.',
+  })
+  @ApiUnauthorizedResponse({
+    description: '액세스 토큰이 없거나 유효하지 않습니다.',
+    type: ErrorResponseDto,
+  })
+  googleLink(): void {}
 
-  /**
-   * Google OAuth 콜백 (login / link 공통)
-   * GET /auth/google/callback
-   */
   @Get('google/callback')
   @UseGuards(PassportAuthGuard('google'))
+  @ApiOperation({ summary: 'Google OAuth 콜백 처리' })
+  @ApiOkResponse({
+    description: '로그인 또는 계정 연결 후 토큰과 사용자 정보를 반환합니다.',
+    type: AuthSignInResponseDto,
+  })
+  @ApiForbiddenResponse({
+    description: '계정 연결 요청이 올바르지 않습니다.',
+    type: ErrorResponseDto,
+  })
   googleCallback(@Request() req: OAuthRequest) {
     return this.handleOAuthCallback(req.user);
   }
@@ -74,32 +96,38 @@ export class AuthController {
    * GitHub OAuth
    * ====================================================== */
 
-  /**
-   * GitHub OAuth 로그인 시작
-   * GET /auth/github
-   */
   @Get('github')
   @UseGuards(PassportAuthGuard('github'))
-  githubLogin(): void {
-    // Passport가 GitHub 로그인 페이지로 리다이렉트
-  }
+  @ApiOperation({ summary: 'GitHub OAuth 로그인 시작' })
+  @ApiOkResponse({
+    description: 'OAuth 제공자 로그인 페이지로 리다이렉트됩니다.',
+  })
+  githubLogin(): void {}
 
-  /**
-   * GitHub OAuth 계정 연결 시작 (JWT 필요)
-   * GET /auth/github/link
-   */
   @Get('github/link')
   @UseGuards(JwtAccessGuard, PassportAuthGuard('github'))
-  githubLink(): void {
-    // JWT 인증 후 GitHub 로그인 페이지로 리다이렉트
-  }
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'GitHub OAuth 계정 연결 시작' })
+  @ApiOkResponse({
+    description: '인증 후 OAuth 제공자 로그인 페이지로 리다이렉트됩니다.',
+  })
+  @ApiUnauthorizedResponse({
+    description: '액세스 토큰이 없거나 유효하지 않습니다.',
+    type: ErrorResponseDto,
+  })
+  githubLink(): void {}
 
-  /**
-   * GitHub OAuth 콜백 (login / link 공통)
-   * GET /auth/github/callback
-   */
   @Get('github/callback')
   @UseGuards(PassportAuthGuard('github'))
+  @ApiOperation({ summary: 'GitHub OAuth 콜백 처리' })
+  @ApiOkResponse({
+    description: '로그인 또는 계정 연결 후 토큰과 사용자 정보를 반환합니다.',
+    type: AuthSignInResponseDto,
+  })
+  @ApiForbiddenResponse({
+    description: '계정 연결 요청이 올바르지 않습니다.',
+    type: ErrorResponseDto,
+  })
   githubCallback(@Request() req: OAuthRequest) {
     return this.handleOAuthCallback(req.user);
   }
@@ -108,12 +136,19 @@ export class AuthController {
    * Account Switch
    * ====================================================== */
 
-  /**
-   * 연동된 계정 전환
-   * POST /auth/switch-user
-   */
   @UseGuards(JwtAccessGuard)
   @Post('switch-user')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '연동된 계정으로 전환' })
+  @ApiBody({ type: SwitchUserDto })
+  @ApiOkResponse({
+    description: '선택한 계정 기준으로 새 토큰과 사용자 정보를 반환합니다.',
+    type: AuthSignInResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: '액세스 토큰이 없거나 유효하지 않습니다.',
+    type: ErrorResponseDto,
+  })
   switchUser(
     @Request() req: { user: AuthContext },
     @Body() switchUserDto: SwitchUserDto,
@@ -125,12 +160,18 @@ export class AuthController {
     );
   }
 
-  /**
-   * Access Token 재발급
-   * POST /auth/refresh
-   */
   @UseGuards(JwtRefreshGuard)
   @Post('refresh')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '액세스 토큰 재발급' })
+  @ApiOkResponse({
+    description: '새 액세스 토큰을 반환합니다.',
+    type: RefreshAccessTokenResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: '리프레시 토큰이 없거나 유효하지 않습니다.',
+    type: ErrorResponseDto,
+  })
   refresh(
     @Request()
     req: {
@@ -141,12 +182,18 @@ export class AuthController {
     return this.refreshAccessTokenUseCase.execute(req.user, req.refreshToken);
   }
 
-  /**
-   * 로그아웃 (현재 플랫폼 세션만)
-   * POST /auth/logout
-   */
   @UseGuards(JwtAccessGuard)
   @Post('logout')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: '현재 플랫폼 로그아웃' })
+  @ApiOkResponse({
+    description: '현재 플랫폼의 리프레시 토큰 세션을 만료시킵니다.',
+    type: LogoutResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: '액세스 토큰이 없거나 유효하지 않습니다.',
+    type: ErrorResponseDto,
+  })
   logout(@Request() req: { user: AuthContext }) {
     return this.logoutUseCase.execute(req.user.accountId, req.user.platform);
   }

--- a/src/auth/presentation/dtos/auth-response.dto.ts
+++ b/src/auth/presentation/dtos/auth-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AuthUserResponseDto {
+  @ApiProperty({ example: 'cmauthuser123' })
+  id: string;
+
+  @ApiProperty({ example: '홍길동' })
+  displayName: string;
+
+  @ApiProperty({
+    example: 'https://avatars.githubusercontent.com/u/1?v=4',
+    nullable: true,
+  })
+  avatarUrl: string | null;
+}
+
+export class AuthSignInResponseDto {
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
+  access_token: string;
+
+  @ApiProperty({ example: 'refresh-token-value' })
+  refresh_token: string;
+
+  @ApiProperty({ type: AuthUserResponseDto })
+  user: AuthUserResponseDto;
+}
+
+export class RefreshAccessTokenResponseDto {
+  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
+  access_token: string;
+}
+
+export class LogoutResponseDto {
+  @ApiProperty({ example: true })
+  success: true;
+}

--- a/src/auth/presentation/dtos/auth-token.dto.ts
+++ b/src/auth/presentation/dtos/auth-token.dto.ts
@@ -1,5 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
 export class AuthTokenDto {
+  @ApiProperty({ example: 'access-token-value' })
   accessToken: string;
+
+  @ApiPropertyOptional({ example: 'refresh-token-value' })
   refreshToken?: string;
+
+  @ApiPropertyOptional({ example: 3600 })
   expiresIn?: number;
 }

--- a/src/auth/presentation/dtos/oauth-code.dto.ts
+++ b/src/auth/presentation/dtos/oauth-code.dto.ts
@@ -1,10 +1,13 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class OAuthCodeDto {
+  @ApiProperty({ example: 'oauth-authorization-code' })
   @IsString()
   @IsNotEmpty()
   code: string;
 
+  @ApiPropertyOptional({ example: 'pkce-code-verifier' })
   @IsOptional()
   @IsString()
   codeVerifier?: string;

--- a/src/auth/presentation/dtos/switch-user.dto.ts
+++ b/src/auth/presentation/dtos/switch-user.dto.ts
@@ -1,6 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class SwitchUserDto {
+  @ApiProperty({
+    example: 'cmauth123',
+    description: '전환할 OAuth 계정 ID',
+  })
   @IsString()
   @IsNotEmpty()
   authAccountId: string;

--- a/src/clips/presentation/clips.controller.ts
+++ b/src/clips/presentation/clips.controller.ts
@@ -15,12 +15,31 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { JwtAccessGuard } from 'src/common/presentation/guards/jwt-access.guard';
 import { AuthContext } from 'src/common/types/auth-context.type';
 import { ApplicationExceptionFilter } from 'src/common/presentation/filters/application-exception.filter';
 import { CreateClipDto } from './dtos/create-clip.dto';
 import { ListClipsQueryDto } from './dtos/list-clips-query.dto';
 import { UpdateClipDto } from './dtos/update-clip.dto';
+import {
+  ClipCursorPageResponseDto,
+  ClipResponseDto,
+  LikeClipResponseDto,
+  RecentViewedClipListResponseDto,
+} from './dtos/clip-response.dto';
 import { DeleteClipUseCase } from '../application/usecases/delete-clip.usecase';
 import { CreateClipUseCase } from '../application/usecases/create-clip.usecase';
 import { UpdateClipUseCase } from '../application/usecases/update-clip.usecase';
@@ -32,9 +51,16 @@ import { UnlikeClipUseCase } from '../application/usecases/unlike-clip.usecase';
 import { RecordClipViewUseCase } from '../application/usecases/record-clip-view.usecase';
 import { ListRecentViewedClipsUseCase } from '../application/usecases/list-recent-viewed-clips.usecase';
 import { ClipsError } from '../application/errors/clips.error';
+import { ErrorResponseDto } from 'src/common/presentation/dtos/error-response.dto';
 
 @Controller('clips')
 @UseFilters(ApplicationExceptionFilter)
+@ApiTags('Clips')
+@ApiBearerAuth('access-token')
+@ApiUnauthorizedResponse({
+  description: '액세스 토큰이 없거나 유효하지 않습니다.',
+  type: ErrorResponseDto,
+})
 export class ClipsController {
   constructor(
     private readonly createClipUseCase: CreateClipUseCase,
@@ -49,9 +75,24 @@ export class ClipsController {
     private readonly listRecentViewedClipsUseCase: ListRecentViewedClipsUseCase,
   ) {}
 
-  // 클립 목록을 커서 기반으로 조회한다.
   @Get()
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '클립 목록 조회' })
+  @ApiQuery({ name: 'folderId', required: false })
+  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'favorite', required: false, enum: ['true'] })
+  @ApiQuery({ name: 'recent', required: false, enum: ['true'] })
+  @ApiQuery({
+    name: 'type',
+    required: true,
+    enum: ['TEXT', 'COLOR', 'IMAGE', 'ALL'],
+  })
+  @ApiQuery({ name: 'q', required: false })
+  @ApiOkResponse({
+    description:
+      '폴더, 좋아요, 최근 기준의 커서 페이지네이션 결과를 반환합니다.',
+    type: ClipCursorPageResponseDto,
+  })
   getClips(
     @Request() req: { user: AuthContext },
     @Query() query: ListClipsQueryDto,
@@ -95,17 +136,31 @@ export class ClipsController {
     });
   }
 
-  // 최근 조회한 클립 50개를 최신순으로 조회한다.
   @Get('views/recent')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '최근 조회한 클립 목록 조회' })
+  @ApiOkResponse({
+    description: '최근 조회한 클립 최대 50개를 반환합니다.',
+    type: RecentViewedClipListResponseDto,
+  })
   getRecentViewedClips(@Request() req: { user: AuthContext }) {
     return this.listRecentViewedClipsUseCase.execute(req.user.userId);
   }
 
-  // multipart 입력에서 file 우선 규칙으로 타입을 판별해 클립을 생성한다.
   @Post()
   @UseGuards(JwtAccessGuard)
   @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: '클립 생성' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ type: CreateClipDto })
+  @ApiOkResponse({
+    description: '생성된 클립 정보를 반환합니다.',
+    type: ClipResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   createClip(
     @Request() req: { user: AuthContext },
     @Body() dto: CreateClipDto,
@@ -120,10 +175,21 @@ export class ClipsController {
     );
   }
 
-  // multipart 입력에서 file/text가 주어지면 타입을 재판별해 클립을 갱신한다.
   @Patch(':id')
   @UseGuards(JwtAccessGuard)
   @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: '클립 수정' })
+  @ApiParam({ name: 'id', description: '클립 ID' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ type: UpdateClipDto })
+  @ApiOkResponse({
+    description: '수정된 클립 정보를 반환합니다.',
+    type: ClipResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '클립 또는 폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   updateClip(
     @Request() req: { user: AuthContext },
     @Param('id') id: string,
@@ -140,17 +206,34 @@ export class ClipsController {
     );
   }
 
-  // 클립을 즉시 제거하지 않고 deletedAt만 기록한다.
   @Delete(':id')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '클립 삭제' })
+  @ApiParam({ name: 'id', description: '클립 ID' })
+  @ApiOkResponse({
+    description: '소프트 삭제된 클립 정보를 반환합니다.',
+    type: ClipResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '클립을 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   deleteClip(@Request() req: { user: AuthContext }, @Param('id') id: string) {
     return this.deleteClipUseCase.execute(req.user.userId, id);
   }
 
-  // 클립 조회 이벤트를 기록한다.
   @Post(':id/views')
   @HttpCode(204)
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '클립 조회 이벤트 기록' })
+  @ApiParam({ name: 'id', description: '클립 ID' })
+  @ApiNoContentResponse({
+    description: '조회 이벤트가 기록되었습니다.',
+  })
+  @ApiNotFoundResponse({
+    description: '클립을 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   recordClipView(
     @Request() req: { user: AuthContext },
     @Param('id') id: string,
@@ -158,16 +241,34 @@ export class ClipsController {
     return this.recordClipViewUseCase.execute(req.user.userId, id);
   }
 
-  // 클립에 좋아요를 등록한다.
   @Post(':id/likes')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '클립 좋아요 등록' })
+  @ApiParam({ name: 'id', description: '클립 ID' })
+  @ApiOkResponse({
+    description: '좋아요 상태를 반환합니다.',
+    type: LikeClipResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '클립을 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   likeClip(@Request() req: { user: AuthContext }, @Param('id') id: string) {
     return this.likeClipUseCase.execute(req.user.userId, id);
   }
 
-  // 클립 좋아요를 취소한다.
   @Delete(':id/likes')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '클립 좋아요 취소' })
+  @ApiParam({ name: 'id', description: '클립 ID' })
+  @ApiOkResponse({
+    description: '좋아요 상태를 반환합니다.',
+    type: LikeClipResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '클립을 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   unlikeClip(@Request() req: { user: AuthContext }, @Param('id') id: string) {
     return this.unlikeClipUseCase.execute(req.user.userId, id);
   }

--- a/src/clips/presentation/dtos/clip-response.dto.ts
+++ b/src/clips/presentation/dtos/clip-response.dto.ts
@@ -1,0 +1,78 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ClipTagResponseDto {
+  @ApiProperty({ example: 'cmtag123' })
+  id: string;
+
+  @ApiProperty({ example: 'backend' })
+  name: string;
+}
+
+export class ClipResponseDto {
+  @ApiProperty({ example: 'cmclip123' })
+  id: string;
+
+  @ApiProperty({ enum: ['TEXT', 'COLOR', 'IMAGE'], example: 'TEXT' })
+  type: 'TEXT' | 'COLOR' | 'IMAGE';
+
+  @ApiProperty({ example: '회의 메모' })
+  title: string;
+
+  @ApiProperty({ example: '정리할 내용', nullable: true })
+  textContent: string | null;
+
+  @ApiProperty({ example: '#FFFFFF', nullable: true })
+  colorHex: string | null;
+
+  @ApiProperty({ example: 'https://cdn.example.com/image.png', nullable: true })
+  imageUrl: string | null;
+
+  @ApiProperty({ example: 'cmworkspace123' })
+  workspaceId: string;
+
+  @ApiProperty({ example: 'cmfolder123' })
+  folderId: string;
+
+  @ApiProperty({ example: '2026-06-05T08:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2026-06-05T08:10:00.000Z' })
+  updatedAt: Date;
+
+  @ApiProperty({ example: null, nullable: true })
+  deletedAt: Date | null;
+}
+
+export class ClipListItemResponseDto extends ClipResponseDto {
+  @ApiProperty({ example: false })
+  likeByMe: boolean;
+
+  @ApiProperty({ type: [ClipTagResponseDto] })
+  tags: ClipTagResponseDto[];
+}
+
+export class ClipCursorPageResponseDto {
+  @ApiProperty({ type: [ClipListItemResponseDto] })
+  items: ClipListItemResponseDto[];
+
+  @ApiProperty({ example: true })
+  hasMore: boolean;
+
+  @ApiProperty({ example: 'cmclip123', nullable: true })
+  nextCursor: string | null;
+}
+
+export class RecentViewedClipItemResponseDto extends ClipListItemResponseDto {
+  @ApiProperty({ example: 'cmview123' })
+  viewId: string;
+}
+
+export class RecentViewedClipListResponseDto {
+  @ApiProperty({ type: [RecentViewedClipItemResponseDto] })
+  items: RecentViewedClipItemResponseDto[];
+}
+
+export class LikeClipResponseDto {
+  @ApiProperty({ example: true })
+  likeByMe: boolean;
+}

--- a/src/clips/presentation/dtos/create-clip.dto.ts
+++ b/src/clips/presentation/dtos/create-clip.dto.ts
@@ -1,12 +1,26 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Allow, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateClipDto {
+  @ApiProperty({ example: 'cmfolder123' })
   @IsString()
   @IsNotEmpty()
   folderId: string;
 
+  @ApiPropertyOptional({
+    example: '회의 메모입니다.',
+    description: 'TEXT 또는 COLOR 클립 생성 시 사용합니다.',
+  })
   @IsOptional()
   @IsString()
   @IsNotEmpty()
   text?: string;
+
+  @ApiPropertyOptional({
+    type: 'string',
+    format: 'binary',
+    description: 'IMAGE 클립 생성 시 업로드 파일',
+  })
+  @Allow()
+  file?: unknown;
 }

--- a/src/clips/presentation/dtos/list-clips-query.dto.ts
+++ b/src/clips/presentation/dtos/list-clips-query.dto.ts
@@ -1,26 +1,47 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional, IsString } from 'class-validator';
 
 export class ListClipsQueryDto {
+  @ApiPropertyOptional({ example: 'cmfolder123' })
   @IsOptional()
   @IsString()
   folderId?: string;
 
-  // 초기 요청 null 허용
+  @ApiPropertyOptional({
+    example: 'cmclip123',
+    description: '다음 페이지 조회에 사용할 커서',
+  })
   @IsOptional()
   @IsString()
   cursor?: string;
 
+  @ApiPropertyOptional({
+    enum: ['true'],
+    description: '좋아요 목록 조회 여부',
+  })
   @IsOptional()
   @IsIn(['true'])
   favorite?: 'true';
 
+  @ApiPropertyOptional({
+    enum: ['true'],
+    description: '최근 클립 목록 조회 여부',
+  })
   @IsOptional()
   @IsIn(['true'])
   recent?: 'true';
 
+  @ApiProperty({
+    enum: ['TEXT', 'COLOR', 'IMAGE', 'ALL'],
+    example: 'TEXT',
+  })
   @IsIn(['TEXT', 'COLOR', 'IMAGE', 'ALL'])
   type: 'TEXT' | 'COLOR' | 'IMAGE' | 'ALL';
 
+  @ApiPropertyOptional({
+    example: '회의',
+    description: '제목/내용 검색어',
+  })
   @IsOptional()
   @IsString()
   q?: string;

--- a/src/clips/presentation/dtos/update-clip.dto.ts
+++ b/src/clips/presentation/dtos/update-clip.dto.ts
@@ -1,13 +1,27 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Allow, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class UpdateClipDto {
+  @ApiPropertyOptional({ example: 'cmfolder123' })
   @IsOptional()
   @IsString()
   @IsNotEmpty()
   folderId?: string;
 
+  @ApiPropertyOptional({
+    example: '#FF5733',
+    description: 'TEXT 또는 COLOR 값 수정 시 사용합니다.',
+  })
   @IsOptional()
   @IsString()
   @IsNotEmpty()
   text?: string;
+
+  @ApiPropertyOptional({
+    type: 'string',
+    format: 'binary',
+    description: '이미지 클립으로 교체할 파일',
+  })
+  @Allow()
+  file?: unknown;
 }

--- a/src/common/presentation/dtos/error-response.dto.ts
+++ b/src/common/presentation/dtos/error-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ErrorResponseDto {
+  @ApiProperty({ example: 400 })
+  statusCode: number;
+
+  @ApiProperty({ example: '잘못된 요청입니다.' })
+  message: string;
+
+  @ApiProperty({ example: 'Bad Request' })
+  error: string;
+}

--- a/src/folders/presentation/dtos/create-folder.dto.ts
+++ b/src/folders/presentation/dtos/create-folder.dto.ts
@@ -1,6 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateFolderDto {
+  @ApiProperty({ example: '업무' })
   @IsString()
   @IsNotEmpty()
   name: string;

--- a/src/folders/presentation/dtos/folder-response.dto.ts
+++ b/src/folders/presentation/dtos/folder-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FolderResponseDto {
+  @ApiProperty({ example: 'cmfolder123' })
+  id: string;
+
+  @ApiProperty({ example: '업무' })
+  name: string;
+
+  @ApiProperty({ example: 1.5 })
+  order: number;
+
+  @ApiProperty({ example: 'cmworkspace123' })
+  workspaceId: string;
+
+  @ApiProperty({ example: '2026-06-05T08:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2026-06-05T08:10:00.000Z' })
+  updatedAt: Date;
+
+  @ApiProperty({ example: null, nullable: true })
+  deletedAt: Date | null;
+}

--- a/src/folders/presentation/dtos/reorder-folder.dto.ts
+++ b/src/folders/presentation/dtos/reorder-folder.dto.ts
@@ -1,15 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class ReorderFolderDto {
+  @ApiProperty({ example: 'cmfolder-target' })
   @IsString()
   @IsNotEmpty()
   targetId: string;
 
+  @ApiPropertyOptional({ example: 'cmfolder-after' })
   @IsOptional()
   @IsString()
   @IsNotEmpty()
   afterId?: string;
 
+  @ApiPropertyOptional({ example: 'cmfolder-before' })
   @IsOptional()
   @IsString()
   @IsNotEmpty()

--- a/src/folders/presentation/dtos/update-folder.dto.ts
+++ b/src/folders/presentation/dtos/update-folder.dto.ts
@@ -1,6 +1,8 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class UpdateFolderDto {
+  @ApiPropertyOptional({ example: '개인' })
   @IsOptional()
   @IsString()
   @IsNotEmpty()

--- a/src/folders/presentation/folders.controller.ts
+++ b/src/folders/presentation/folders.controller.ts
@@ -10,21 +10,39 @@ import {
   UseGuards,
   UseFilters,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { JwtAccessGuard } from 'src/common/presentation/guards/jwt-access.guard';
 import { AuthContext } from 'src/common/types/auth-context.type';
 import { ApplicationExceptionFilter } from 'src/common/presentation/filters/application-exception.filter';
 import { CreateFolderDto } from './dtos/create-folder.dto';
 import { ReorderFolderDto } from './dtos/reorder-folder.dto';
 import { UpdateFolderDto } from './dtos/update-folder.dto';
+import { FolderResponseDto } from './dtos/folder-response.dto';
 import { GetFolderUseCase } from '../application/usecases/get-folder.usecase';
 import { ListFoldersUseCase } from '../application/usecases/list-folders.usecase';
 import { ReorderFolderUseCase } from '../application/usecases/reorder-folder.usecase';
 import { DeleteFolderUseCase } from '../application/usecases/delete-folder.usecase';
 import { CreateFolderUseCase } from '../application/usecases/create-folder.usecase';
 import { UpdateFolderUseCase } from '../application/usecases/update-folder.usecase';
+import { ErrorResponseDto } from 'src/common/presentation/dtos/error-response.dto';
 
 @Controller('folders')
 @UseFilters(ApplicationExceptionFilter)
+@ApiTags('Folders')
+@ApiBearerAuth('access-token')
+@ApiUnauthorizedResponse({
+  description: '액세스 토큰이 없거나 유효하지 않습니다.',
+  type: ErrorResponseDto,
+})
 export class FoldersController {
   constructor(
     private readonly listFoldersUseCase: ListFoldersUseCase,
@@ -35,23 +53,42 @@ export class FoldersController {
     private readonly deleteFolderUseCase: DeleteFolderUseCase,
   ) {}
 
-  // 폴더 목록 조회
   @Get()
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '폴더 목록 조회' })
+  @ApiOkResponse({
+    description: '개인 워크스페이스의 폴더 목록을 반환합니다.',
+    type: FolderResponseDto,
+    isArray: true,
+  })
   getFolders(@Request() req: { user: AuthContext }) {
     return this.listFoldersUseCase.execute(req.user.userId);
   }
 
-  // 폴더 단건 조회
   @Get(':id')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '폴더 단건 조회' })
+  @ApiParam({ name: 'id', description: '폴더 ID' })
+  @ApiOkResponse({
+    description: '선택한 폴더를 반환합니다.',
+    type: FolderResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   getFolder(@Request() req: { user: AuthContext }, @Param('id') id: string) {
     return this.getFolderUseCase.execute(req.user.userId, id);
   }
 
-  // 폴더 생성
   @Post()
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '폴더 생성' })
+  @ApiBody({ type: CreateFolderDto })
+  @ApiOkResponse({
+    description: '생성된 폴더를 반환합니다.',
+    type: FolderResponseDto,
+  })
   createFolder(
     @Request() req: { user: AuthContext },
     @Body() dto: CreateFolderDto,
@@ -59,9 +96,18 @@ export class FoldersController {
     return this.createFolderUseCase.execute(req.user.userId, dto.name);
   }
 
-  // 폴더 순서 변경
   @Patch('reorder')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '폴더 순서 변경' })
+  @ApiBody({ type: ReorderFolderDto })
+  @ApiOkResponse({
+    description: '정렬이 변경된 대상 폴더를 반환합니다.',
+    type: FolderResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '대상 폴더 또는 기준 폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   reorderFolder(
     @Request() req: { user: AuthContext },
     @Body() dto: ReorderFolderDto,
@@ -69,9 +115,19 @@ export class FoldersController {
     return this.reorderFolderUseCase.execute(req.user.userId, dto);
   }
 
-  // 폴더 이름 수정
   @Patch(':id')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '폴더 이름 수정' })
+  @ApiParam({ name: 'id', description: '폴더 ID' })
+  @ApiBody({ type: UpdateFolderDto })
+  @ApiOkResponse({
+    description: '수정된 폴더를 반환합니다.',
+    type: FolderResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   updateFolder(
     @Request() req: { user: AuthContext },
     @Param('id') id: string,
@@ -80,9 +136,18 @@ export class FoldersController {
     return this.updateFolderUseCase.execute(req.user.userId, id, dto.name);
   }
 
-  // 폴더 삭제(소프트 삭제)
   @Delete(':id')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '폴더 삭제' })
+  @ApiParam({ name: 'id', description: '폴더 ID' })
+  @ApiOkResponse({
+    description: '소프트 삭제된 폴더를 반환합니다.',
+    type: FolderResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
   deleteFolder(@Request() req: { user: AuthContext }, @Param('id') id: string) {
     return this.deleteFolderUseCase.execute(req.user.userId, id);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,59 @@
 import 'dotenv/config';
+import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+const parseAllowedCorsPorts = (raw?: string) =>
+  new Set(
+    (raw ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+
+const isAllowedCorsOrigin = (origin: string, allowedPorts: Set<string>) => {
+  try {
+    const url = new URL(origin);
+    const isLocalHost =
+      url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+
+    if (!isLocalHost) {
+      return false;
+    }
+
+    return allowedPorts.has(url.port);
+  } catch {
+    return false;
+  }
+};
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const allowedCorsPorts = parseAllowedCorsPorts(
+    process.env.CORS_ALLOWED_PORTS,
+  );
+
+  const corsOptions: CorsOptions = {
+    origin(origin, callback) {
+      // 브라우저가 아닌 서버 간 요청/헬스체크는 Origin 헤더가 없을 수 있다.
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+
+      if (isAllowedCorsOrigin(origin, allowedCorsPorts)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(null, false);
+    },
+    credentials: true,
+  };
+
+  app.enableCors(corsOptions);
 
   app.useGlobalPipes(
     new ValidationPipe({
@@ -13,6 +62,37 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('Easy Clip API')
+    .setDescription('개인 MVP 기준 Easy Clip 백엔드 OpenAPI 문서')
+    .setVersion('1.0.0')
+    .addTag('Auth', 'OAuth 로그인, 계정 전환, 토큰 재발급, 로그아웃 API')
+    .addTag('Clips', '클립 생성, 수정, 삭제, 목록, 좋아요, 최근 조회 API')
+    .addTag('Folders', '개인 워크스페이스 폴더 관리 API')
+    .addTag('Users', '내 프로필 및 사용자 설정 API')
+    .addTag('Workspaces', '개인 워크스페이스 구독 정보 API')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'JWT access token을 입력하세요.',
+      },
+      'access-token',
+    )
+    .build();
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('docs', app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+      tagsSorter: 'alpha',
+      operationsSorter: 'alpha',
+      docExpansion: 'none',
+      filter: true,
+    },
+  });
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/src/users/presentation/dtos/update-me.dto.ts
+++ b/src/users/presentation/dtos/update-me.dto.ts
@@ -1,3 +1,4 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsNotEmpty,
   IsOptional,
@@ -7,11 +8,16 @@ import {
 } from 'class-validator';
 
 export class UpdateMeDto {
+  @ApiPropertyOptional({ example: '홍길동' })
   @ValidateIf((_, value) => value !== undefined)
   @IsString()
   @IsNotEmpty()
   displayName?: string;
 
+  @ApiPropertyOptional({
+    example: 'https://avatars.githubusercontent.com/u/1?v=4',
+    nullable: true,
+  })
   @IsOptional()
   @IsUrl()
   avatarUrl?: string | null;

--- a/src/users/presentation/dtos/update-user-settings.dto.ts
+++ b/src/users/presentation/dtos/update-user-settings.dto.ts
@@ -1,11 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
 import { USER_THEMES, type UserTheme } from '../../domain/user.types';
 
 export class UpdateUserSettingsDto {
+  @ApiPropertyOptional({ enum: USER_THEMES, example: 'SYSTEM' })
   @IsOptional()
   @IsIn(USER_THEMES)
   theme?: UserTheme;
 
+  @ApiPropertyOptional({ enum: ['ko', 'en'], example: 'ko' })
   @IsOptional()
   @IsIn(['ko', 'en'])
   language?: 'ko' | 'en';

--- a/src/users/presentation/dtos/user-response.dto.ts
+++ b/src/users/presentation/dtos/user-response.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserAuthAccountResponseDto {
+  @ApiProperty({ example: 'cmauth123' })
+  id: string;
+
+  @ApiProperty({ enum: ['GOOGLE', 'GITHUB'], example: 'GOOGLE' })
+  provider: 'GOOGLE' | 'GITHUB';
+
+  @ApiProperty({ example: 'user@example.com' })
+  email: string;
+}
+
+export class UserProfileResponseDto {
+  @ApiProperty({ example: 'cmuser123' })
+  id: string;
+
+  @ApiProperty({ example: '홍길동' })
+  displayName: string;
+
+  @ApiProperty({
+    example: 'https://avatars.githubusercontent.com/u/1?v=4',
+    nullable: true,
+  })
+  avatarUrl: string | null;
+
+  @ApiProperty({ type: [UserAuthAccountResponseDto] })
+  authAccounts: UserAuthAccountResponseDto[];
+}
+
+export class UserSettingsResponseDto {
+  @ApiProperty({ example: 'cmsettings123' })
+  id: string;
+
+  @ApiProperty({ example: 'cmuser123' })
+  userId: string;
+
+  @ApiProperty({ enum: ['LIGHT', 'DARK', 'SYSTEM'], example: 'SYSTEM' })
+  theme: 'LIGHT' | 'DARK' | 'SYSTEM';
+
+  @ApiProperty({ example: 'ko' })
+  language: string;
+}
+
+export class DeleteMeResponseDto {
+  @ApiProperty({ example: true })
+  success: true;
+}

--- a/src/users/presentation/users.controller.ts
+++ b/src/users/presentation/users.controller.ts
@@ -8,6 +8,14 @@ import {
   UseGuards,
   UseFilters,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { JwtAccessGuard } from 'src/common/presentation/guards/jwt-access.guard';
 import { AuthContext } from 'src/common/types/auth-context.type';
 import { ApplicationExceptionFilter } from 'src/common/presentation/filters/application-exception.filter';
@@ -18,9 +26,21 @@ import { GetUserSettingsUseCase } from '../application/usecases/get-user-setting
 import { UpdateUserSettingsUseCase } from '../application/usecases/update-user-settings.usecase';
 import { UpdateMeDto } from './dtos/update-me.dto';
 import { UpdateUserSettingsDto } from './dtos/update-user-settings.dto';
+import {
+  DeleteMeResponseDto,
+  UserProfileResponseDto,
+  UserSettingsResponseDto,
+} from './dtos/user-response.dto';
+import { ErrorResponseDto } from 'src/common/presentation/dtos/error-response.dto';
 
 @Controller('users')
 @UseFilters(ApplicationExceptionFilter)
+@ApiTags('Users')
+@ApiBearerAuth('access-token')
+@ApiUnauthorizedResponse({
+  description: '액세스 토큰이 없거나 유효하지 않습니다.',
+  type: ErrorResponseDto,
+})
 export class UsersController {
   constructor(
     private readonly getMeUseCase: GetMeUseCase,
@@ -32,12 +52,23 @@ export class UsersController {
 
   @Get('me')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '내 프로필 조회' })
+  @ApiOkResponse({
+    description: '현재 로그인한 사용자 프로필을 반환합니다.',
+    type: UserProfileResponseDto,
+  })
   getMe(@Request() req: { user: AuthContext }) {
     return this.getMeUseCase.execute(req.user.userId, req.user.accountId);
   }
 
   @Patch('me')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '내 프로필 수정' })
+  @ApiBody({ type: UpdateMeDto })
+  @ApiOkResponse({
+    description: '수정된 사용자 프로필을 반환합니다.',
+    type: UserProfileResponseDto,
+  })
   updateMe(@Request() req: { user: AuthContext }, @Body() dto: UpdateMeDto) {
     return this.updateMeUseCase.execute(
       req.user.userId,
@@ -48,18 +79,34 @@ export class UsersController {
 
   @Delete('me')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '내 계정 삭제' })
+  @ApiOkResponse({
+    description: '계정 삭제 결과를 반환합니다.',
+    type: DeleteMeResponseDto,
+  })
   deleteMe(@Request() req: { user: AuthContext }) {
     return this.deleteMeUseCase.execute(req.user.userId);
   }
 
   @Get('me/settings')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '내 설정 조회' })
+  @ApiOkResponse({
+    description: '현재 사용자 설정을 반환합니다.',
+    type: UserSettingsResponseDto,
+  })
   getMySettings(@Request() req: { user: AuthContext }) {
     return this.getUserSettingsUseCase.execute(req.user.userId);
   }
 
   @Patch('me/settings')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '내 설정 수정' })
+  @ApiBody({ type: UpdateUserSettingsDto })
+  @ApiOkResponse({
+    description: '저장된 사용자 설정을 반환합니다.',
+    type: UserSettingsResponseDto,
+  })
   updateMySettings(
     @Request() req: { user: AuthContext },
     @Body() dto: UpdateUserSettingsDto,

--- a/src/workspaces/presentation/dtos/update-my-subscription.dto.ts
+++ b/src/workspaces/presentation/dtos/update-my-subscription.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
 import {
   WorkspaceSubscriptionAction,
@@ -8,9 +9,17 @@ const SUBSCRIPTION_ACTION_VALUES = Object.values(WorkspaceSubscriptionAction);
 const SUBSCRIPTION_PLAN_VALUES = Object.values(WorkspaceSubscriptionPlan);
 
 export class UpdateMySubscriptionDto {
+  @ApiProperty({
+    enum: SUBSCRIPTION_ACTION_VALUES,
+    example: WorkspaceSubscriptionAction.CHANGE_PLAN,
+  })
   @IsIn(SUBSCRIPTION_ACTION_VALUES)
   type: (typeof SUBSCRIPTION_ACTION_VALUES)[number];
 
+  @ApiPropertyOptional({
+    enum: SUBSCRIPTION_PLAN_VALUES,
+    example: WorkspaceSubscriptionPlan.PRO,
+  })
   @IsOptional()
   @IsIn(SUBSCRIPTION_PLAN_VALUES)
   plan?: (typeof SUBSCRIPTION_PLAN_VALUES)[number];

--- a/src/workspaces/presentation/dtos/workspace-response.dto.ts
+++ b/src/workspaces/presentation/dtos/workspace-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MySubscriptionResponseDto {
+  @ApiProperty({ enum: ['FREE', 'PRO'], example: 'FREE' })
+  plan: 'FREE' | 'PRO';
+
+  @ApiProperty({ enum: ['ACTIVE', 'CANCELED', 'EXPIRED'], example: 'ACTIVE' })
+  status: 'ACTIVE' | 'CANCELED' | 'EXPIRED';
+
+  @ApiProperty({ example: false })
+  autoRenew: boolean;
+
+  @ApiProperty({ example: null, nullable: true })
+  currentPeriodEnd: Date | null;
+}

--- a/src/workspaces/presentation/workspaces.controller.ts
+++ b/src/workspaces/presentation/workspaces.controller.ts
@@ -7,15 +7,31 @@ import {
   UseGuards,
   UseFilters,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { AuthContext } from 'src/common/types/auth-context.type';
 import { JwtAccessGuard } from 'src/common/presentation/guards/jwt-access.guard';
 import { ApplicationExceptionFilter } from 'src/common/presentation/filters/application-exception.filter';
 import { GetMySubscriptionUseCase } from '../application/usecases/get-my-subscription.usecase';
 import { UpdateMySubscriptionUseCase } from '../application/usecases/update-my-subscription.usecase';
 import { UpdateMySubscriptionDto } from './dtos/update-my-subscription.dto';
+import { MySubscriptionResponseDto } from './dtos/workspace-response.dto';
+import { ErrorResponseDto } from 'src/common/presentation/dtos/error-response.dto';
 
 @Controller('workspaces')
 @UseFilters(ApplicationExceptionFilter)
+@ApiTags('Workspaces')
+@ApiBearerAuth('access-token')
+@ApiUnauthorizedResponse({
+  description: '액세스 토큰이 없거나 유효하지 않습니다.',
+  type: ErrorResponseDto,
+})
 export class WorkspacesController {
   constructor(
     private readonly getMySubscriptionUseCase: GetMySubscriptionUseCase,
@@ -24,12 +40,23 @@ export class WorkspacesController {
 
   @Get('me/subscription')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '내 구독 정보 조회' })
+  @ApiOkResponse({
+    description: '개인 워크스페이스의 구독 상태를 반환합니다.',
+    type: MySubscriptionResponseDto,
+  })
   getMySubscription(@Request() req: { user: AuthContext }) {
     return this.getMySubscriptionUseCase.execute(req.user.userId);
   }
 
   @Patch('me/subscription')
   @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '내 구독 정보 변경' })
+  @ApiBody({ type: UpdateMySubscriptionDto })
+  @ApiOkResponse({
+    description: '변경 후 구독 상태를 반환합니다.',
+    type: MySubscriptionResponseDto,
+  })
   updateMySubscription(
     @Request() req: { user: AuthContext },
     @Body() dto: UpdateMySubscriptionDto,


### PR DESCRIPTION
## Description

Swagger 기반 OpenAPI 문서를 추가하고, 현재 개인 MVP 범위의 주요 API를 문서화했습니다.
추가로 로컬 개발에서 발생하던 CORS 문제를 환경변수 기반 허용 포트 설정으로 정리했습니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #43, refs #43
- Requires #
- Ports #

## TODOs

- [x] 변경 사항 셀프 리뷰
- [ ] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- `@nestjs/swagger`, `swagger-ui-express`를 추가하고 `/docs` 문서 엔드포인트를 구성했습니다.
- `auth`, `clips`, `folders`, `users`, `workspaces` 컨트롤러에 Swagger 태그, 요청/응답, 에러 응답 문서를 추가했습니다.
- 요청/응답 DTO에 Swagger 데코레이터를 적용하고 문서용 응답 DTO를 추가했습니다.
- `multipart/form-data` 기반 클립 생성/수정 요청에서 `file` 필드를 검증 허용하도록 조정했습니다.
- CORS를 `CORS_ALLOWED_PORTS` 환경변수 기반으로 제어하도록 변경했습니다.
- OAuth 관련 임시 URL/리다이렉트 실험 코드는 제거하고 기존 JSON 응답 방식으로 정리했습니다.

## Performance/Scaling

주요 영향은 문서화와 개발 환경 설정 정리이며, 런타임 비즈니스 로직 변경은 최소화했습니다.

## Testing done

- `pnpm build` 통과
- `pnpm test` 통과
- `pnpm lint` 통과
- `pnpm test:e2e` 미실행

## Additional information

Swagger UI는 `/docs`에서 확인할 수 있으며, 태그 검색과 정렬 기준을 적용했습니다.