### PR TITLE
#22/feat(clip) : 휴지통 관리 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { ConfigModule } from '@nestjs/config';
 import { FoldersModule } from './folders/folders.module';
 import { ClipsModule } from './clips/clips.module';
 import { WorkspacesModule } from './workspaces/workspaces.module';
+import { TrashModule } from './trash/trash.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { WorkspacesModule } from './workspaces/workspaces.module';
     FoldersModule,
     ClipsModule,
     WorkspacesModule,
+    TrashModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/infrastructure/jwt-auth-session.port.ts
+++ b/src/auth/infrastructure/jwt-auth-session.port.ts
@@ -63,7 +63,7 @@ export class JwtAuthSessionPort implements AuthSessionPort {
   signAccessToken(context: AuthContext): string {
     return this.jwtService.sign(this.toJwtPayload(context), {
       secret: this.config.getOrThrow<string>('JWT_ACCESS_SECRET'),
-      expiresIn: '15m',
+      expiresIn: '30m',
       audience: 'api',
       issuer: 'easy-clip',
     });

--- a/src/folders/application/usecases/create-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder.usecase.spec.ts
@@ -13,7 +13,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   createFolder: jest.fn(),
   updateFolderName: jest.fn(),
   updateFolderOrder: jest.fn(),
-  softDeleteFolder: jest.fn(),
+  softDeleteFolderWithClips: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/delete-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/delete-folder.usecase.spec.ts
@@ -13,7 +13,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   createFolder: jest.fn(),
   updateFolderName: jest.fn(),
   updateFolderOrder: jest.fn(),
-  softDeleteFolder: jest.fn(),
+  softDeleteFolderWithClips: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });
@@ -33,11 +33,13 @@ describe('DeleteFolderUseCase', () => {
   it('폴더를 삭제한다', async () => {
     const repo = createRepository();
     repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
-    repo.softDeleteFolder.mockResolvedValue({ id: 'folder-id' } as never);
+    repo.softDeleteFolderWithClips.mockResolvedValue({
+      id: 'folder-id',
+    } as never);
 
     const usecase = new DeleteFolderUseCase(repo);
     await usecase.execute('user-id', 'folder-id');
 
-    expect(repo.softDeleteFolder).toHaveBeenCalledWith('folder-id');
+    expect(repo.softDeleteFolderWithClips).toHaveBeenCalledWith('folder-id');
   });
 });

--- a/src/folders/application/usecases/delete-folder.usecase.ts
+++ b/src/folders/application/usecases/delete-folder.usecase.ts
@@ -20,6 +20,6 @@ export class DeleteFolderUseCase {
       throw new FoldersError('NOT_FOUND', '폴더를 찾을 수 없습니다.');
     }
 
-    return this.foldersRepository.softDeleteFolder(folder.id);
+    return this.foldersRepository.softDeleteFolderWithClips(folder.id);
   }
 }

--- a/src/folders/application/usecases/get-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/get-folder.usecase.spec.ts
@@ -13,7 +13,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   createFolder: jest.fn(),
   updateFolderName: jest.fn(),
   updateFolderOrder: jest.fn(),
-  softDeleteFolder: jest.fn(),
+  softDeleteFolderWithClips: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/list-folders.usecase.spec.ts
+++ b/src/folders/application/usecases/list-folders.usecase.spec.ts
@@ -13,7 +13,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   createFolder: jest.fn(),
   updateFolderName: jest.fn(),
   updateFolderOrder: jest.fn(),
-  softDeleteFolder: jest.fn(),
+  softDeleteFolderWithClips: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/reorder-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/reorder-folder.usecase.spec.ts
@@ -13,7 +13,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   createFolder: jest.fn(),
   updateFolderName: jest.fn(),
   updateFolderOrder: jest.fn(),
-  softDeleteFolder: jest.fn(),
+  softDeleteFolderWithClips: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/update-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder.usecase.spec.ts
@@ -13,7 +13,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   createFolder: jest.fn(),
   updateFolderName: jest.fn(),
   updateFolderOrder: jest.fn(),
-  softDeleteFolder: jest.fn(),
+  softDeleteFolderWithClips: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/domain/folders.repository.ts
+++ b/src/folders/domain/folders.repository.ts
@@ -31,7 +31,7 @@ export interface FoldersRepository {
   createFolder(params: CreateFolderParams): Promise<Folder>;
   updateFolderName(folderId: string, name: string): Promise<Folder>;
   updateFolderOrder(folderId: string, order: number): Promise<Folder>;
-  softDeleteFolder(folderId: string): Promise<Folder>;
+  softDeleteFolderWithClips(folderId: string): Promise<Folder>;
   findPreviousFolderOrder(params: FolderOrderParams): Promise<number | null>;
   findNextFolderOrder(params: FolderOrderParams): Promise<number | null>;
 }

--- a/src/folders/infrastructure/prisma-folders.repository.ts
+++ b/src/folders/infrastructure/prisma-folders.repository.ts
@@ -141,10 +141,24 @@ export class PrismaFoldersRepository implements FoldersRepository {
     });
   }
 
-  async softDeleteFolder(folderId: string): Promise<Folder> {
-    return this.prisma.folder.update({
-      where: { id: folderId },
-      data: { deletedAt: new Date() },
+  async softDeleteFolderWithClips(folderId: string): Promise<Folder> {
+    return this.prisma.$transaction(async (tx) => {
+      const deletedAt = new Date();
+
+      await tx.clip.updateMany({
+        where: {
+          folderId,
+          deletedAt: null,
+        },
+        data: {
+          deletedAt,
+        },
+      });
+
+      return tx.folder.update({
+        where: { id: folderId },
+        data: { deletedAt },
+      });
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,7 @@ async function bootstrap() {
     .addTag('Folders', '개인 워크스페이스 폴더 관리 API')
     .addTag('Users', '내 프로필 및 사용자 설정 API')
     .addTag('Workspaces', '개인 워크스페이스 구독 정보 API')
+    .addTag('Trash', '휴지통 조회, 복구, 영구 삭제 API')
     .addBearerAuth(
       {
         type: 'http',

--- a/src/trash/application/errors/trash.error.ts
+++ b/src/trash/application/errors/trash.error.ts
@@ -1,0 +1,13 @@
+import {
+  ApplicationError,
+  ApplicationErrorCode,
+} from '../../../common/application/application.error';
+
+export type TrashErrorCode = ApplicationErrorCode;
+
+export class TrashError extends ApplicationError {
+  constructor(code: TrashErrorCode, message: string) {
+    super(code, message);
+    this.name = 'TrashError';
+  }
+}

--- a/src/trash/application/usecases/delete-trash-clip.usecase.spec.ts
+++ b/src/trash/application/usecases/delete-trash-clip.usecase.spec.ts
@@ -1,0 +1,44 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { DeleteTrashClipUseCase } from './delete-trash-clip.usecase';
+import { TrashRepository } from '../../domain/trash.repository';
+
+const createRepository = (): jest.Mocked<TrashRepository> => ({
+  findDeletedClips: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreClip: jest.fn(),
+  hardDeleteClip: jest.fn(),
+  findDeletedFolders: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  restoreFolderWithClips: jest.fn(),
+  hardDeleteFolderWithClips: jest.fn(),
+});
+
+describe('DeleteTrashClipUseCase', () => {
+  it('휴지통 클립이 없으면 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findDeletedClipById.mockResolvedValue(null);
+
+    const usecase = new DeleteTrashClipUseCase(repo);
+
+    await expect(usecase.execute('user-1', 'clip-1')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('휴지통 클립을 영구 삭제한다', async () => {
+    const repo = createRepository();
+    repo.findDeletedClipById.mockResolvedValue({
+      id: 'clip-1',
+      title: '삭제된 클립',
+      type: 'TEXT',
+      folderId: 'folder-1',
+      deletedAt: new Date(),
+    });
+
+    const usecase = new DeleteTrashClipUseCase(repo);
+    const result = await usecase.execute('user-1', 'clip-1');
+
+    expect(repo.hardDeleteClip).toHaveBeenCalledWith('clip-1');
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/trash/application/usecases/delete-trash-clip.usecase.ts
+++ b/src/trash/application/usecases/delete-trash-clip.usecase.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  TRASH_REPOSITORY,
+  type TrashRepository,
+} from '../../domain/trash.repository';
+import { TrashError } from '../errors/trash.error';
+
+@Injectable()
+export class DeleteTrashClipUseCase {
+  constructor(
+    @Inject(TRASH_REPOSITORY)
+    private readonly trashRepository: TrashRepository,
+  ) {}
+
+  async execute(userId: string, clipId: string) {
+    const clip = await this.trashRepository.findDeletedClipById(userId, clipId);
+
+    if (!clip) {
+      throw new TrashError('NOT_FOUND', '휴지통 클립을 찾을 수 없습니다.');
+    }
+
+    await this.trashRepository.hardDeleteClip(clip.id);
+
+    return {
+      success: true as const,
+    };
+  }
+}

--- a/src/trash/application/usecases/delete-trash-folder.usecase.spec.ts
+++ b/src/trash/application/usecases/delete-trash-folder.usecase.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { DeleteTrashFolderUseCase } from './delete-trash-folder.usecase';
+import { TrashRepository } from '../../domain/trash.repository';
+
+const createRepository = (): jest.Mocked<TrashRepository> => ({
+  findDeletedClips: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreClip: jest.fn(),
+  hardDeleteClip: jest.fn(),
+  findDeletedFolders: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  restoreFolderWithClips: jest.fn(),
+  hardDeleteFolderWithClips: jest.fn(),
+});
+
+describe('DeleteTrashFolderUseCase', () => {
+  it('휴지통 폴더가 없으면 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findDeletedFolderById.mockResolvedValue(null);
+
+    const usecase = new DeleteTrashFolderUseCase(repo);
+
+    await expect(usecase.execute('user-1', 'folder-1')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('휴지통 폴더와 하위 클립을 함께 영구 삭제한다', async () => {
+    const repo = createRepository();
+    repo.findDeletedFolderById.mockResolvedValue({
+      id: 'folder-1',
+      name: '삭제된 폴더',
+      deletedAt: new Date(),
+    });
+
+    const usecase = new DeleteTrashFolderUseCase(repo);
+    const result = await usecase.execute('user-1', 'folder-1');
+
+    expect(repo.hardDeleteFolderWithClips).toHaveBeenCalledWith('folder-1');
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/trash/application/usecases/delete-trash-folder.usecase.ts
+++ b/src/trash/application/usecases/delete-trash-folder.usecase.ts
@@ -1,0 +1,31 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  TRASH_REPOSITORY,
+  type TrashRepository,
+} from '../../domain/trash.repository';
+import { TrashError } from '../errors/trash.error';
+
+@Injectable()
+export class DeleteTrashFolderUseCase {
+  constructor(
+    @Inject(TRASH_REPOSITORY)
+    private readonly trashRepository: TrashRepository,
+  ) {}
+
+  async execute(userId: string, folderId: string) {
+    const folder = await this.trashRepository.findDeletedFolderById(
+      userId,
+      folderId,
+    );
+
+    if (!folder) {
+      throw new TrashError('NOT_FOUND', '휴지통 폴더를 찾을 수 없습니다.');
+    }
+
+    await this.trashRepository.hardDeleteFolderWithClips(folder.id);
+
+    return {
+      success: true as const,
+    };
+  }
+}

--- a/src/trash/application/usecases/list-trash-clips.usecase.spec.ts
+++ b/src/trash/application/usecases/list-trash-clips.usecase.spec.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ListTrashClipsUseCase } from './list-trash-clips.usecase';
+import { TrashRepository } from '../../domain/trash.repository';
+
+const createRepository = (): jest.Mocked<TrashRepository> => ({
+  findDeletedClips: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreClip: jest.fn(),
+  hardDeleteClip: jest.fn(),
+  findDeletedFolders: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  restoreFolderWithClips: jest.fn(),
+  hardDeleteFolderWithClips: jest.fn(),
+});
+
+describe('ListTrashClipsUseCase', () => {
+  it('휴지통 클립 목록을 반환한다', async () => {
+    const repo = createRepository();
+    repo.findDeletedClips.mockResolvedValue([
+      {
+        id: 'clip-1',
+        title: '삭제된 클립',
+        type: 'TEXT',
+        folderId: 'folder-1',
+        deletedAt: new Date(),
+      },
+    ]);
+
+    const usecase = new ListTrashClipsUseCase(repo);
+    const result = await usecase.execute('user-1');
+
+    expect(repo.findDeletedClips).toHaveBeenCalledWith('user-1');
+    expect(result.items).toHaveLength(1);
+  });
+});

--- a/src/trash/application/usecases/list-trash-clips.usecase.ts
+++ b/src/trash/application/usecases/list-trash-clips.usecase.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  TRASH_REPOSITORY,
+  type TrashRepository,
+} from '../../domain/trash.repository';
+
+@Injectable()
+export class ListTrashClipsUseCase {
+  constructor(
+    @Inject(TRASH_REPOSITORY)
+    private readonly trashRepository: TrashRepository,
+  ) {}
+
+  async execute(userId: string) {
+    return {
+      items: await this.trashRepository.findDeletedClips(userId),
+    };
+  }
+}

--- a/src/trash/application/usecases/list-trash-folders.usecase.spec.ts
+++ b/src/trash/application/usecases/list-trash-folders.usecase.spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ListTrashFoldersUseCase } from './list-trash-folders.usecase';
+import { TrashRepository } from '../../domain/trash.repository';
+
+const createRepository = (): jest.Mocked<TrashRepository> => ({
+  findDeletedClips: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreClip: jest.fn(),
+  hardDeleteClip: jest.fn(),
+  findDeletedFolders: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  restoreFolderWithClips: jest.fn(),
+  hardDeleteFolderWithClips: jest.fn(),
+});
+
+describe('ListTrashFoldersUseCase', () => {
+  it('휴지통 폴더 목록을 반환한다', async () => {
+    const repo = createRepository();
+    repo.findDeletedFolders.mockResolvedValue([
+      {
+        id: 'folder-1',
+        name: '삭제된 폴더',
+        deletedAt: new Date(),
+      },
+    ]);
+
+    const usecase = new ListTrashFoldersUseCase(repo);
+    const result = await usecase.execute('user-1');
+
+    expect(repo.findDeletedFolders).toHaveBeenCalledWith('user-1');
+    expect(result.items).toHaveLength(1);
+  });
+});

--- a/src/trash/application/usecases/list-trash-folders.usecase.ts
+++ b/src/trash/application/usecases/list-trash-folders.usecase.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  TRASH_REPOSITORY,
+  type TrashRepository,
+} from '../../domain/trash.repository';
+
+@Injectable()
+export class ListTrashFoldersUseCase {
+  constructor(
+    @Inject(TRASH_REPOSITORY)
+    private readonly trashRepository: TrashRepository,
+  ) {}
+
+  async execute(userId: string) {
+    return {
+      items: await this.trashRepository.findDeletedFolders(userId),
+    };
+  }
+}

--- a/src/trash/application/usecases/restore-trash-clip.usecase.spec.ts
+++ b/src/trash/application/usecases/restore-trash-clip.usecase.spec.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { RestoreTrashClipUseCase } from './restore-trash-clip.usecase';
+import { TrashRepository } from '../../domain/trash.repository';
+
+const createRepository = (): jest.Mocked<TrashRepository> => ({
+  findDeletedClips: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreClip: jest.fn(),
+  hardDeleteClip: jest.fn(),
+  findDeletedFolders: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  restoreFolderWithClips: jest.fn(),
+  hardDeleteFolderWithClips: jest.fn(),
+});
+
+describe('RestoreTrashClipUseCase', () => {
+  it('휴지통 클립이 없으면 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findDeletedClipById.mockResolvedValue(null);
+
+    const usecase = new RestoreTrashClipUseCase(repo);
+
+    await expect(usecase.execute('user-1', 'clip-1')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('휴지통 클립을 복구한다', async () => {
+    const repo = createRepository();
+    const clip = {
+      id: 'clip-1',
+      title: '삭제된 클립',
+      type: 'TEXT' as const,
+      folderId: 'folder-1',
+      deletedAt: new Date(),
+    };
+    repo.findDeletedClipById.mockResolvedValue(clip);
+    repo.restoreClip.mockResolvedValue({
+      ...clip,
+      deletedAt: null as never,
+    });
+
+    const usecase = new RestoreTrashClipUseCase(repo);
+    await usecase.execute('user-1', 'clip-1');
+
+    expect(repo.restoreClip).toHaveBeenCalledWith('clip-1');
+  });
+});

--- a/src/trash/application/usecases/restore-trash-clip.usecase.ts
+++ b/src/trash/application/usecases/restore-trash-clip.usecase.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  TRASH_REPOSITORY,
+  type TrashRepository,
+} from '../../domain/trash.repository';
+import { TrashError } from '../errors/trash.error';
+
+@Injectable()
+export class RestoreTrashClipUseCase {
+  constructor(
+    @Inject(TRASH_REPOSITORY)
+    private readonly trashRepository: TrashRepository,
+  ) {}
+
+  async execute(userId: string, clipId: string) {
+    const clip = await this.trashRepository.findDeletedClipById(userId, clipId);
+
+    if (!clip) {
+      throw new TrashError('NOT_FOUND', '휴지통 클립을 찾을 수 없습니다.');
+    }
+
+    return this.trashRepository.restoreClip(clip.id);
+  }
+}

--- a/src/trash/application/usecases/restore-trash-folder.usecase.spec.ts
+++ b/src/trash/application/usecases/restore-trash-folder.usecase.spec.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { RestoreTrashFolderUseCase } from './restore-trash-folder.usecase';
+import { TrashRepository } from '../../domain/trash.repository';
+
+const createRepository = (): jest.Mocked<TrashRepository> => ({
+  findDeletedClips: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreClip: jest.fn(),
+  hardDeleteClip: jest.fn(),
+  findDeletedFolders: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  restoreFolderWithClips: jest.fn(),
+  hardDeleteFolderWithClips: jest.fn(),
+});
+
+describe('RestoreTrashFolderUseCase', () => {
+  it('휴지통 폴더가 없으면 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findDeletedFolderById.mockResolvedValue(null);
+
+    const usecase = new RestoreTrashFolderUseCase(repo);
+
+    await expect(usecase.execute('user-1', 'folder-1')).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('휴지통 폴더와 하위 클립을 함께 복구한다', async () => {
+    const repo = createRepository();
+    const folder = {
+      id: 'folder-1',
+      name: '삭제된 폴더',
+      deletedAt: new Date(),
+    };
+    repo.findDeletedFolderById.mockResolvedValue(folder);
+    repo.restoreFolderWithClips.mockResolvedValue({
+      ...folder,
+      deletedAt: null as never,
+    });
+
+    const usecase = new RestoreTrashFolderUseCase(repo);
+    await usecase.execute('user-1', 'folder-1');
+
+    expect(repo.restoreFolderWithClips).toHaveBeenCalledWith('folder-1');
+  });
+});

--- a/src/trash/application/usecases/restore-trash-folder.usecase.ts
+++ b/src/trash/application/usecases/restore-trash-folder.usecase.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  TRASH_REPOSITORY,
+  type TrashRepository,
+} from '../../domain/trash.repository';
+import { TrashError } from '../errors/trash.error';
+
+@Injectable()
+export class RestoreTrashFolderUseCase {
+  constructor(
+    @Inject(TRASH_REPOSITORY)
+    private readonly trashRepository: TrashRepository,
+  ) {}
+
+  async execute(userId: string, folderId: string) {
+    const folder = await this.trashRepository.findDeletedFolderById(
+      userId,
+      folderId,
+    );
+
+    if (!folder) {
+      throw new TrashError('NOT_FOUND', '휴지통 폴더를 찾을 수 없습니다.');
+    }
+
+    return this.trashRepository.restoreFolderWithClips(folder.id);
+  }
+}

--- a/src/trash/domain/trash.repository.ts
+++ b/src/trash/domain/trash.repository.ts
@@ -1,0 +1,20 @@
+import { TrashClipItem, TrashFolderItem } from './trash.types';
+
+export const TRASH_REPOSITORY = Symbol('TRASH_REPOSITORY');
+
+export interface TrashRepository {
+  findDeletedClips(userId: string): Promise<TrashClipItem[]>;
+  findDeletedClipById(
+    userId: string,
+    clipId: string,
+  ): Promise<TrashClipItem | null>;
+  restoreClip(clipId: string): Promise<TrashClipItem>;
+  hardDeleteClip(clipId: string): Promise<void>;
+  findDeletedFolders(userId: string): Promise<TrashFolderItem[]>;
+  findDeletedFolderById(
+    userId: string,
+    folderId: string,
+  ): Promise<TrashFolderItem | null>;
+  restoreFolderWithClips(folderId: string): Promise<TrashFolderItem>;
+  hardDeleteFolderWithClips(folderId: string): Promise<void>;
+}

--- a/src/trash/domain/trash.types.ts
+++ b/src/trash/domain/trash.types.ts
@@ -1,0 +1,13 @@
+export type TrashFolderItem = {
+  id: string;
+  name: string;
+  deletedAt: Date;
+};
+
+export type TrashClipItem = {
+  id: string;
+  title: string;
+  type: 'TEXT' | 'COLOR' | 'IMAGE';
+  folderId: string;
+  deletedAt: Date;
+};

--- a/src/trash/domain/trash.types.ts
+++ b/src/trash/domain/trash.types.ts
@@ -1,7 +1,7 @@
 export type TrashFolderItem = {
   id: string;
   name: string;
-  deletedAt: Date;
+  deletedAt: Date | null;
 };
 
 export type TrashClipItem = {
@@ -9,5 +9,5 @@ export type TrashClipItem = {
   title: string;
   type: 'TEXT' | 'COLOR' | 'IMAGE';
   folderId: string;
-  deletedAt: Date;
+  deletedAt: Date | null;
 };

--- a/src/trash/infrastructure/prisma-trash.repository.ts
+++ b/src/trash/infrastructure/prisma-trash.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { WorkspaceType } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { TrashRepository } from '../domain/trash.repository';
 import { TrashClipItem, TrashFolderItem } from '../domain/trash.types';
@@ -15,6 +16,7 @@ export class PrismaTrashRepository implements TrashRepository {
         },
         workspace: {
           ownerUserId: userId,
+          type: WorkspaceType.PERSONAL,
         },
       },
       orderBy: [{ deletedAt: 'desc' }, { id: 'desc' }],
@@ -40,6 +42,7 @@ export class PrismaTrashRepository implements TrashRepository {
         },
         workspace: {
           ownerUserId: userId,
+          type: WorkspaceType.PERSONAL,
         },
       },
       select: {
@@ -82,6 +85,7 @@ export class PrismaTrashRepository implements TrashRepository {
         },
         workspace: {
           ownerUserId: userId,
+          type: WorkspaceType.PERSONAL,
         },
       },
       orderBy: [{ deletedAt: 'desc' }, { id: 'desc' }],
@@ -105,6 +109,7 @@ export class PrismaTrashRepository implements TrashRepository {
         },
         workspace: {
           ownerUserId: userId,
+          type: WorkspaceType.PERSONAL,
         },
       },
       select: {

--- a/src/trash/infrastructure/prisma-trash.repository.ts
+++ b/src/trash/infrastructure/prisma-trash.repository.ts
@@ -1,0 +1,161 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { TrashRepository } from '../domain/trash.repository';
+import { TrashClipItem, TrashFolderItem } from '../domain/trash.types';
+
+@Injectable()
+export class PrismaTrashRepository implements TrashRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findDeletedClips(userId: string): Promise<TrashClipItem[]> {
+    return this.prisma.clip.findMany({
+      where: {
+        deletedAt: {
+          not: null,
+        },
+        workspace: {
+          ownerUserId: userId,
+        },
+      },
+      orderBy: [{ deletedAt: 'desc' }, { id: 'desc' }],
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        folderId: true,
+        deletedAt: true,
+      },
+    }) as Promise<TrashClipItem[]>;
+  }
+
+  async findDeletedClipById(
+    userId: string,
+    clipId: string,
+  ): Promise<TrashClipItem | null> {
+    return this.prisma.clip.findFirst({
+      where: {
+        id: clipId,
+        deletedAt: {
+          not: null,
+        },
+        workspace: {
+          ownerUserId: userId,
+        },
+      },
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        folderId: true,
+        deletedAt: true,
+      },
+    }) as Promise<TrashClipItem | null>;
+  }
+
+  async restoreClip(clipId: string): Promise<TrashClipItem> {
+    return this.prisma.clip.update({
+      where: { id: clipId },
+      data: {
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        folderId: true,
+        deletedAt: true,
+      },
+    }) as Promise<TrashClipItem>;
+  }
+
+  async hardDeleteClip(clipId: string): Promise<void> {
+    await this.prisma.clip.delete({
+      where: { id: clipId },
+    });
+  }
+
+  async findDeletedFolders(userId: string): Promise<TrashFolderItem[]> {
+    return this.prisma.folder.findMany({
+      where: {
+        deletedAt: {
+          not: null,
+        },
+        workspace: {
+          ownerUserId: userId,
+        },
+      },
+      orderBy: [{ deletedAt: 'desc' }, { id: 'desc' }],
+      select: {
+        id: true,
+        name: true,
+        deletedAt: true,
+      },
+    }) as Promise<TrashFolderItem[]>;
+  }
+
+  async findDeletedFolderById(
+    userId: string,
+    folderId: string,
+  ): Promise<TrashFolderItem | null> {
+    return this.prisma.folder.findFirst({
+      where: {
+        id: folderId,
+        deletedAt: {
+          not: null,
+        },
+        workspace: {
+          ownerUserId: userId,
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        deletedAt: true,
+      },
+    }) as Promise<TrashFolderItem | null>;
+  }
+
+  async restoreFolderWithClips(folderId: string): Promise<TrashFolderItem> {
+    return this.prisma.$transaction(async (tx) => {
+      await tx.clip.updateMany({
+        where: {
+          folderId,
+          deletedAt: {
+            not: null,
+          },
+        },
+        data: {
+          deletedAt: null,
+        },
+      });
+
+      const folder = await tx.folder.update({
+        where: { id: folderId },
+        data: {
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          name: true,
+          deletedAt: true,
+        },
+      });
+
+      return folder as TrashFolderItem;
+    });
+  }
+
+  async hardDeleteFolderWithClips(folderId: string): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      await tx.clip.deleteMany({
+        where: {
+          folderId,
+        },
+      });
+
+      await tx.folder.delete({
+        where: { id: folderId },
+      });
+    });
+  }
+}

--- a/src/trash/presentation/dtos/trash-response.dto.ts
+++ b/src/trash/presentation/dtos/trash-response.dto.ts
@@ -13,8 +13,8 @@ export class TrashClipResponseDto {
   @ApiProperty({ example: 'cmfolder123' })
   folderId: string;
 
-  @ApiProperty({ example: '2026-06-05T09:00:00.000Z' })
-  deletedAt: Date;
+  @ApiProperty({ example: '2026-06-05T09:00:00.000Z', nullable: true })
+  deletedAt: Date | null;
 }
 
 export class TrashClipListResponseDto {
@@ -29,8 +29,8 @@ export class TrashFolderResponseDto {
   @ApiProperty({ example: '삭제된 폴더' })
   name: string;
 
-  @ApiProperty({ example: '2026-06-05T09:00:00.000Z' })
-  deletedAt: Date;
+  @ApiProperty({ example: '2026-06-05T09:00:00.000Z', nullable: true })
+  deletedAt: Date | null;
 }
 
 export class TrashFolderListResponseDto {

--- a/src/trash/presentation/dtos/trash-response.dto.ts
+++ b/src/trash/presentation/dtos/trash-response.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TrashClipResponseDto {
+  @ApiProperty({ example: 'cmclip123' })
+  id: string;
+
+  @ApiProperty({ example: '삭제된 클립' })
+  title: string;
+
+  @ApiProperty({ enum: ['TEXT', 'COLOR', 'IMAGE'], example: 'TEXT' })
+  type: 'TEXT' | 'COLOR' | 'IMAGE';
+
+  @ApiProperty({ example: 'cmfolder123' })
+  folderId: string;
+
+  @ApiProperty({ example: '2026-06-05T09:00:00.000Z' })
+  deletedAt: Date;
+}
+
+export class TrashClipListResponseDto {
+  @ApiProperty({ type: [TrashClipResponseDto] })
+  items: TrashClipResponseDto[];
+}
+
+export class TrashFolderResponseDto {
+  @ApiProperty({ example: 'cmfolder123' })
+  id: string;
+
+  @ApiProperty({ example: '삭제된 폴더' })
+  name: string;
+
+  @ApiProperty({ example: '2026-06-05T09:00:00.000Z' })
+  deletedAt: Date;
+}
+
+export class TrashFolderListResponseDto {
+  @ApiProperty({ type: [TrashFolderResponseDto] })
+  items: TrashFolderResponseDto[];
+}
+
+export class TrashDeleteResponseDto {
+  @ApiProperty({ example: true })
+  success: true;
+}

--- a/src/trash/presentation/trash.controller.ts
+++ b/src/trash/presentation/trash.controller.ts
@@ -1,0 +1,153 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Request,
+  UseGuards,
+  UseFilters,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { ApplicationExceptionFilter } from 'src/common/presentation/filters/application-exception.filter';
+import { JwtAccessGuard } from 'src/common/presentation/guards/jwt-access.guard';
+import { ErrorResponseDto } from 'src/common/presentation/dtos/error-response.dto';
+import { AuthContext } from 'src/common/types/auth-context.type';
+import { DeleteTrashClipUseCase } from '../application/usecases/delete-trash-clip.usecase';
+import { DeleteTrashFolderUseCase } from '../application/usecases/delete-trash-folder.usecase';
+import { ListTrashClipsUseCase } from '../application/usecases/list-trash-clips.usecase';
+import { ListTrashFoldersUseCase } from '../application/usecases/list-trash-folders.usecase';
+import { RestoreTrashClipUseCase } from '../application/usecases/restore-trash-clip.usecase';
+import { RestoreTrashFolderUseCase } from '../application/usecases/restore-trash-folder.usecase';
+import {
+  TrashClipListResponseDto,
+  TrashClipResponseDto,
+  TrashDeleteResponseDto,
+  TrashFolderListResponseDto,
+  TrashFolderResponseDto,
+} from './dtos/trash-response.dto';
+
+@Controller('trash')
+@UseFilters(ApplicationExceptionFilter)
+@ApiTags('Trash')
+@ApiBearerAuth('access-token')
+@ApiUnauthorizedResponse({
+  description: '액세스 토큰이 없거나 유효하지 않습니다.',
+  type: ErrorResponseDto,
+})
+export class TrashController {
+  constructor(
+    private readonly listTrashClipsUseCase: ListTrashClipsUseCase,
+    private readonly restoreTrashClipUseCase: RestoreTrashClipUseCase,
+    private readonly deleteTrashClipUseCase: DeleteTrashClipUseCase,
+    private readonly listTrashFoldersUseCase: ListTrashFoldersUseCase,
+    private readonly restoreTrashFolderUseCase: RestoreTrashFolderUseCase,
+    private readonly deleteTrashFolderUseCase: DeleteTrashFolderUseCase,
+  ) {}
+
+  @Get('clips')
+  @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '휴지통 클립 목록 조회' })
+  @ApiOkResponse({
+    description: '삭제된 클립 목록을 반환합니다.',
+    type: TrashClipListResponseDto,
+  })
+  getTrashClips(@Request() req: { user: AuthContext }) {
+    return this.listTrashClipsUseCase.execute(req.user.userId);
+  }
+
+  @Patch('clips/:id/restore')
+  @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '휴지통 클립 복구' })
+  @ApiParam({ name: 'id', description: '클립 ID' })
+  @ApiOkResponse({
+    description: '복구된 클립 메타데이터를 반환합니다.',
+    type: TrashClipResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '휴지통 클립을 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
+  restoreTrashClip(
+    @Request() req: { user: AuthContext },
+    @Param('id') id: string,
+  ) {
+    return this.restoreTrashClipUseCase.execute(req.user.userId, id);
+  }
+
+  @Delete('clips/:id')
+  @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '휴지통 클립 영구 삭제' })
+  @ApiParam({ name: 'id', description: '클립 ID' })
+  @ApiOkResponse({
+    description: '영구 삭제 결과를 반환합니다.',
+    type: TrashDeleteResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '휴지통 클립을 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
+  deleteTrashClip(
+    @Request() req: { user: AuthContext },
+    @Param('id') id: string,
+  ) {
+    return this.deleteTrashClipUseCase.execute(req.user.userId, id);
+  }
+
+  @Get('folders')
+  @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '휴지통 폴더 목록 조회' })
+  @ApiOkResponse({
+    description: '삭제된 폴더 목록을 반환합니다.',
+    type: TrashFolderListResponseDto,
+  })
+  getTrashFolders(@Request() req: { user: AuthContext }) {
+    return this.listTrashFoldersUseCase.execute(req.user.userId);
+  }
+
+  @Patch('folders/:id/restore')
+  @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '휴지통 폴더 복구' })
+  @ApiParam({ name: 'id', description: '폴더 ID' })
+  @ApiOkResponse({
+    description: '복구된 폴더 메타데이터를 반환합니다.',
+    type: TrashFolderResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '휴지통 폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
+  restoreTrashFolder(
+    @Request() req: { user: AuthContext },
+    @Param('id') id: string,
+  ) {
+    return this.restoreTrashFolderUseCase.execute(req.user.userId, id);
+  }
+
+  @Delete('folders/:id')
+  @UseGuards(JwtAccessGuard)
+  @ApiOperation({ summary: '휴지통 폴더 영구 삭제' })
+  @ApiParam({ name: 'id', description: '폴더 ID' })
+  @ApiOkResponse({
+    description: '영구 삭제 결과를 반환합니다.',
+    type: TrashDeleteResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '휴지통 폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
+  deleteTrashFolder(
+    @Request() req: { user: AuthContext },
+    @Param('id') id: string,
+  ) {
+    return this.deleteTrashFolderUseCase.execute(req.user.userId, id);
+  }
+}

--- a/src/trash/trash.module.ts
+++ b/src/trash/trash.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { JwtAccessGuard } from 'src/common/presentation/guards/jwt-access.guard';
+import { TRASH_REPOSITORY } from './domain/trash.repository';
+import { PrismaTrashRepository } from './infrastructure/prisma-trash.repository';
+import { TrashController } from './presentation/trash.controller';
+import { ListTrashClipsUseCase } from './application/usecases/list-trash-clips.usecase';
+import { RestoreTrashClipUseCase } from './application/usecases/restore-trash-clip.usecase';
+import { DeleteTrashClipUseCase } from './application/usecases/delete-trash-clip.usecase';
+import { ListTrashFoldersUseCase } from './application/usecases/list-trash-folders.usecase';
+import { RestoreTrashFolderUseCase } from './application/usecases/restore-trash-folder.usecase';
+import { DeleteTrashFolderUseCase } from './application/usecases/delete-trash-folder.usecase';
+
+@Module({
+  controllers: [TrashController],
+  providers: [
+    { provide: TRASH_REPOSITORY, useClass: PrismaTrashRepository },
+    ListTrashClipsUseCase,
+    RestoreTrashClipUseCase,
+    DeleteTrashClipUseCase,
+    ListTrashFoldersUseCase,
+    RestoreTrashFolderUseCase,
+    DeleteTrashFolderUseCase,
+    JwtAccessGuard,
+  ],
+})
+export class TrashModule {}


### PR DESCRIPTION
## Description

개인 워크스페이스 기준의 휴지통 관리 API를 추가했습니다.
삭제된 클립/폴더 조회, 복구, 영구 삭제를 `/trash` 카테고리로 분리했고, 합의된 정책에 맞춰 폴더와 하위 클립의 상태를 함께 관리하도록 정리했습니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #22, refs #22
- Requires #
- Ports #

## TODOs

- [x] 변경 사항 셀프 리뷰
- [ ] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- `trash` 기능 도메인을 추가하고 아래 엔드포인트를 구현했습니다.
  - `GET /trash/clips`
  - `PATCH /trash/clips/:id/restore`
  - `DELETE /trash/clips/:id`
  - `GET /trash/folders`
  - `PATCH /trash/folders/:id/restore`
  - `DELETE /trash/folders/:id`
- 휴지통 조회는 `deletedAt != null` 조건과 `deletedAt desc` 정렬을 적용했습니다.
- 클립/폴더 모두 개인 워크스페이스(`ownerUserId = sub`, `type = PERSONAL`) 소유권 기준으로 필터링하도록 구현했습니다.
- 폴더 복구 시 하위 클립도 함께 복구되도록 구현했습니다.
- 휴지통 폴더 영구 삭제 시 하위 클립도 함께 하드 딜리트되도록 구현했습니다.
- 기존 폴더 삭제 흐름도 정합성을 맞추기 위해, 폴더 소프트 삭제 시 하위 클립이 함께 휴지통으로 이동하도록 보정했습니다.
- Swagger에 `Trash` 태그와 최소 메타데이터 응답 스키마를 추가했습니다.

## Performance/Scaling

휴지통 폴더 복구/영구 삭제는 트랜잭션으로 묶어 폴더와 하위 클립 상태를 함께 처리합니다. 현재 범위는 개인 워크스페이스 기준이며, 대량 삭제/복구 시에도 일관성을 우선하도록 구성했습니다.

## Testing done

- `pnpm build` 통과
- `pnpm test` 통과
- `pnpm lint` 통과
- `pnpm test:e2e` 미실행

## Additional information

합의된 정책을 반영했습니다.
- 폴더 복구 시 하위 클립도 전부 복구
- 휴지통 폴더 영구 삭제 시 하위 클립도 전부 영구 삭제
- 프론트는 클립/폴더 카테고리를 분리해서 표시
- 응답 메타데이터는 최소한만 포함