### PR TITLE
#64/feat(setting) : GitHub Actions 기반 EC2 자동 배포 구성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
 
 jobs:
   test:
@@ -54,5 +55,15 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+
+      - name: Run lint
+        run: pnpm lint
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+
+      - name: Run build
+        run: pnpm build
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/ec2-user/easy-clip-be
+            ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+cd /home/ec2-user/easy-clip-be
+
+export NODE_ENV=production
+
+git pull origin main
+
+pnpm install --frozen-lockfile
+pnpm prisma generate
+pnpm prisma migrate deploy
+pnpm build
+
+pm2 restart easy-clip-be --update-env
+pm2 save


### PR DESCRIPTION
## Description

GitHub Actions를 이용해 `main` 반영 시 EC2로 자동 배포되는 최소 CI/CD 구조를 추가합니다. PR 단계에서는 검증만 수행하고, 운영 배포는 `main` push에서만 실행되도록 분리했습니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #64, refs #64

## TODOs

- [x] 변경 사항 셀프 리뷰
- [ ] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `deploy.sh`를 추가해 EC2에서 `git pull`, `pnpm install`, `pnpm prisma generate`, `pnpm prisma migrate deploy`, `pnpm build`, `pm2 restart`, `pm2 save` 순으로 배포되도록 구성했습니다.
- `.github/workflows/deploy.yml`을 추가해 `main` push 시 `appleboy/ssh-action`으로 EC2에 접속해 `deploy.sh`를 실행하도록 구성했습니다.
- 기존 CI 워크플로우는 PR 대상 브랜치를 `dev`, `main`으로 확장하고 `lint`, `build` 검증을 추가했습니다.

## Performance/Scaling

현재는 단순 SSH 배포 구조이며 무중단 배포나 Blue/Green 전략은 포함하지 않습니다. 이후 필요 시 `pm2 reload`, 헬스체크, 롤백 전략으로 확장할 수 있습니다.

## Testing done

- `bash -n deploy.sh`
- 워크플로우/YAML 및 스크립트 내용 검토

## Additional information

- 실제 배포 동작을 위해 GitHub Repository Secrets에 `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY` 등록이 필요합니다.
- EC2에는 GitHub Actions용 공개키가 `authorized_keys`에 등록되어 있어야 합니다.
