### PR TITLE
#73/refactor(setting) : 로컬 개발용 HTTP 디버그 로그 추가

### DIFF
--- a/src/clips/application/helpers/clip-data.helper.ts
+++ b/src/clips/application/helpers/clip-data.helper.ts
@@ -38,7 +38,10 @@ export function toImageClipData(file: MulterFile, imageUrl: string): ClipData {
 function normalizeUploadedFileName(fileName: string): string {
   const decodedFileName = Buffer.from(fileName, 'latin1').toString('utf8');
 
-  if (isLikelyKoreanFileName(decodedFileName) && !isLikelyKoreanFileName(fileName)) {
+  if (
+    isLikelyKoreanFileName(decodedFileName) &&
+    !isLikelyKoreanFileName(fileName)
+  ) {
     return decodedFileName;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,13 @@
 import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { AppModule } from './app.module';
+import { ApplicationExceptionFilter } from './shared/presentation/filters/application-exception.filter';
+import {
+  isHttpLoggingEnabled,
+  registerHttpLoggingMiddleware,
+} from './shared/presentation/logging/http-logging.helper';
 
 const parseAllowedCorsPorts = (raw?: string) =>
   new Set(
@@ -53,6 +58,11 @@ async function bootstrap() {
   };
 
   app.enableCors(corsOptions);
+  app.useGlobalFilters(new ApplicationExceptionFilter());
+
+  if (isHttpLoggingEnabled(process.env)) {
+    app.use(registerHttpLoggingMiddleware);
+  }
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/shared/presentation/filters/application-exception.filter.ts
+++ b/src/shared/presentation/filters/application-exception.filter.ts
@@ -5,20 +5,45 @@ import {
   ConflictException,
   ExceptionFilter,
   ForbiddenException,
+  HttpException,
   InternalServerErrorException,
+  Logger,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+import type { Request, Response } from 'express';
 import { ApplicationError } from '../../application/application.error';
 
-@Catch(ApplicationError)
+@Catch()
 export class ApplicationExceptionFilter implements ExceptionFilter {
-  catch(exception: ApplicationError, host: ArgumentsHost) {
-    void host;
-    throw this.toHttpException(exception);
+  private readonly logger = new Logger(ApplicationExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const response = ctx.getResponse<Response>();
+
+    const httpException = this.toHttpException(exception);
+    const status = httpException.getStatus();
+    const payload = httpException.getResponse();
+
+    this.logger.error(
+      this.formatErrorLog(request, status, exception),
+      exception instanceof Error ? exception.stack : undefined,
+    );
+
+    response.status(status).json(payload);
   }
 
-  private toHttpException(error: ApplicationError) {
+  private toHttpException(error: unknown): HttpException {
+    if (error instanceof HttpException) {
+      return error;
+    }
+
+    if (!(error instanceof ApplicationError)) {
+      return new InternalServerErrorException('Internal server error');
+    }
+
     switch (error.code) {
       case 'BAD_REQUEST':
         return new BadRequestException(error.message);
@@ -33,5 +58,32 @@ export class ApplicationExceptionFilter implements ExceptionFilter {
       default:
         return new InternalServerErrorException(error.message);
     }
+  }
+
+  private formatErrorLog(
+    request: Request,
+    status: number,
+    exception: unknown,
+  ): string {
+    const base = `${request.method} ${request.originalUrl || request.url} ${status}`;
+    const userId = this.extractUserId(request);
+    const message = this.extractErrorMessage(exception);
+
+    return [base, userId ? `user=${userId}` : undefined, `message=${message}`]
+      .filter(Boolean)
+      .join(' ');
+  }
+
+  private extractUserId(request: Request): string | undefined {
+    const user = request.user as { userId?: string } | undefined;
+    return user?.userId;
+  }
+
+  private extractErrorMessage(exception: unknown): string {
+    if (exception instanceof ApplicationError || exception instanceof Error) {
+      return exception.message;
+    }
+
+    return 'Unknown error';
   }
 }

--- a/src/shared/presentation/logging/http-logging.helper.ts
+++ b/src/shared/presentation/logging/http-logging.helper.ts
@@ -1,0 +1,269 @@
+import { Logger } from '@nestjs/common';
+import type { Request, Response } from 'express';
+
+const logger = new Logger('HttpLogger');
+const MAX_LOG_DEPTH = 3;
+const MAX_OBJECT_KEYS = 12;
+const MAX_ARRAY_ITEMS = 8;
+const MAX_STRING_LENGTH = 160;
+
+type LoggedResponse = {
+  body?: unknown;
+};
+
+export function registerHttpLoggingMiddleware(
+  request: Request,
+  response: Response,
+  next: () => void,
+): void {
+  const startedAt = Date.now();
+  const traceId = buildTraceId();
+  const loggedResponse = patchResponse(response);
+
+  response.on('finish', () => {
+    logger.log(
+      formatRequestLog(request, response.statusCode, startedAt, {
+        traceId,
+        responseBody: loggedResponse.body,
+      }),
+    );
+  });
+
+  next();
+}
+
+export function isHttpLoggingEnabled(env: NodeJS.ProcessEnv): boolean {
+  const override = env.ENABLE_HTTP_LOGGING;
+
+  if (override === 'true') {
+    return true;
+  }
+
+  if (override === 'false') {
+    return false;
+  }
+
+  return env.NODE_ENV !== 'production';
+}
+
+function patchResponse(response: Response): LoggedResponse {
+  const loggedResponse: LoggedResponse = {};
+  const originalJson = response.json.bind(response) as (
+    body: unknown,
+  ) => Response;
+  const originalSend = response.send.bind(response) as (
+    body?: unknown,
+  ) => Response;
+
+  response.json = ((body: unknown) => {
+    loggedResponse.body = body;
+    return originalJson(body);
+  }) as Response['json'];
+
+  response.send = ((body?: unknown) => {
+    loggedResponse.body = body;
+    return originalSend(body);
+  }) as Response['send'];
+
+  return loggedResponse;
+}
+
+function formatRequestLog(
+  request: Request,
+  statusCode: number,
+  startedAt: number,
+  context: {
+    traceId: string;
+    responseBody?: unknown;
+  },
+): string {
+  const durationMs = Date.now() - startedAt;
+  const lines = [
+    [
+      colorizeMethod(request.method),
+      request.originalUrl || request.url,
+      colorizeStatus(statusCode),
+      colorizeDuration(durationMs),
+      colorizeTraceId(context.traceId),
+    ].join(' '),
+    `  user: ${extractUserId(request) ?? '-'}`,
+  ];
+
+  const query = sanitizeValue(request.query);
+  const body = sanitizeValue(request.body);
+  const responseBody = sanitizeValue(context.responseBody);
+
+  if (query !== undefined) {
+    lines.push(`  query: ${stringifyValue(query)}`);
+  }
+
+  if (body !== undefined) {
+    lines.push(`  body: ${stringifyValue(body)}`);
+  }
+
+  if (responseBody !== undefined) {
+    lines.push(`  response: ${stringifyValue(responseBody)}`);
+  }
+
+  return lines.join('\n');
+}
+
+function extractUserId(request: Request): string | undefined {
+  const user = request.user as { userId?: string } | undefined;
+  return user?.userId;
+}
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  if (depth >= MAX_LOG_DEPTH) {
+    return '[Truncated]';
+  }
+
+  if (typeof value === 'string') {
+    return truncateString(value);
+  }
+
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map((item) => sanitizeValue(item, depth + 1));
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return `[Buffer:${value.length}]`;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value).filter(
+      ([key, currentValue]) =>
+        currentValue !== undefined && !isSensitiveKey(key),
+    );
+
+    if (!entries.length) {
+      return undefined;
+    }
+
+    return Object.fromEntries(
+      entries
+        .slice(0, MAX_OBJECT_KEYS)
+        .map(([key, currentValue]) => [
+          key,
+          sanitizeValue(currentValue, depth + 1),
+        ]),
+    );
+  }
+
+  if (typeof value === 'function') {
+    return `[Function:${value.name || 'anonymous'}]`;
+  }
+
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
+
+  return '[Unsupported]';
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function truncateString(value: string): string {
+  if (value.length <= MAX_STRING_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, MAX_STRING_LENGTH)}...`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+
+  return (
+    normalized.includes('token') ||
+    normalized.includes('code') ||
+    normalized.includes('password') ||
+    normalized.includes('authorization') ||
+    normalized.includes('cookie') ||
+    normalized.includes('secret')
+  );
+}
+
+function buildTraceId(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+function colorizeMethod(method: string): string {
+  switch (method.toUpperCase()) {
+    case 'GET':
+      return wrapAnsi(method, 36);
+    case 'POST':
+      return wrapAnsi(method, 32);
+    case 'PATCH':
+    case 'PUT':
+      return wrapAnsi(method, 33);
+    case 'DELETE':
+      return wrapAnsi(method, 31);
+    default:
+      return wrapAnsi(method, 35);
+  }
+}
+
+function colorizeStatus(statusCode: number): string {
+  if (statusCode >= 500) {
+    return wrapAnsi(String(statusCode), 31);
+  }
+
+  if (statusCode >= 400) {
+    return wrapAnsi(String(statusCode), 33);
+  }
+
+  if (statusCode >= 300) {
+    return wrapAnsi(String(statusCode), 36);
+  }
+
+  return wrapAnsi(String(statusCode), 32);
+}
+
+function colorizeDuration(durationMs: number): string {
+  if (durationMs >= 1000) {
+    return wrapAnsi(`${durationMs}ms`, 31);
+  }
+
+  if (durationMs >= 300) {
+    return wrapAnsi(`${durationMs}ms`, 33);
+  }
+
+  return wrapAnsi(`${durationMs}ms`, 90);
+}
+
+function colorizeTraceId(traceId: string): string {
+  return wrapAnsi(`#${traceId}`, 90);
+}
+
+function wrapAnsi(value: string, colorCode: number): string {
+  return `\u001b[${colorCode}m${value}\u001b[0m`;
+}


### PR DESCRIPTION
## Description

로컬 개발 환경에서 API 요청/응답과 에러를 터미널에서 빠르게 확인할 수 있도록 HTTP 디버그 로그를 추가했습니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)

## Linked tickets and other PRs

- Closes #73, refs #73
- Requires #
- Ports #

## TODOs

- [x] 변경 사항 셀프 리뷰
- [ ] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- `main.ts`에 전역 예외 필터와 개발용 HTTP 로깅 미들웨어를 연결했습니다.
- 요청 로그에 method, URL, status, duration, trace id, user, query, body, response 요약을 출력하도록 구성했습니다.
- 상태 코드와 처리 시간은 ANSI 색상으로 구분하고, token/code/password/authorization/cookie/secret 계열 값은 로그에서 제외했습니다.
- `ApplicationExceptionFilter`가 `ApplicationError`, `HttpException`, 예상치 못한 예외를 모두 로깅하도록 확장했습니다.

## Performance/Scaling

- 로컬 개발 환경에서만 활성화되는 디버그 로깅을 기본값으로 두었습니다.
- 운영 환경 관측성은 별도 OpenTelemetry JS + Grafana Cloud 구성을 전제로 하며, 이 변경은 개발용 가시성 보강에 집중합니다.

## Testing done

- `pnpm build`
- `pnpm lint`

## Additional information

- 현재 작업 트리에는 본 PR 범위와 무관한 `src/clips/application/helpers/clip-data.helper.ts` 변경이 별도로 남아 있어 커밋에서 제외했습니다.