### PR TITLE
#75/fix(clip) : 클립 목록 hasMore 응답 누락 수정

### DIFF
--- a/src/clips/application/dtos/clip-cursor-page-output.dto.ts
+++ b/src/clips/application/dtos/clip-cursor-page-output.dto.ts
@@ -2,6 +2,7 @@ import type { ClipListItem } from '../../domain/clip.types';
 
 export type ClipCursorPageOutput = {
   items: ClipListItem[];
+  hasMore: boolean;
   nextCursor: string | null;
 };
 

--- a/src/clips/application/usecases/list-clips.helper.ts
+++ b/src/clips/application/usecases/list-clips.helper.ts
@@ -186,6 +186,7 @@ export const listClipsWithLikedPriority = async ({
   if (likedResult.hasMore) {
     return {
       items: likedResult.items,
+      hasMore: true,
       nextCursor: likedResult.nextCursor,
     };
   }
@@ -203,6 +204,7 @@ export const listClipsWithLikedPriority = async ({
 
     return {
       items: combinedResult.items,
+      hasMore: combinedResult.hasMore,
       nextCursor: combinedResult.nextCursor,
     };
   }
@@ -218,6 +220,7 @@ export const listClipsWithLikedPriority = async ({
 
   return {
     items: likedResult.items,
+    hasMore: hasNonLiked,
     nextCursor:
       hasNonLiked && likedResult.items.length > 0
         ? likedResult.items[likedResult.items.length - 1].id
@@ -264,6 +267,7 @@ export const listRecentClipsWithLikedPriority = async ({
 
     return {
       items: stripRecentViewId(page.items),
+      hasMore: page.hasMore,
       nextCursor: page.nextCursor,
     };
   }
@@ -278,6 +282,7 @@ export const listRecentClipsWithLikedPriority = async ({
   if (likedResult.hasMore) {
     return {
       items: stripRecentViewId(likedResult.items),
+      hasMore: true,
       nextCursor: likedResult.nextCursor,
     };
   }
@@ -295,6 +300,7 @@ export const listRecentClipsWithLikedPriority = async ({
 
     return {
       items: stripRecentViewId(combinedResult.items),
+      hasMore: combinedResult.hasMore,
       nextCursor: combinedResult.nextCursor,
     };
   }
@@ -310,6 +316,7 @@ export const listRecentClipsWithLikedPriority = async ({
 
   return {
     items: stripRecentViewId(likedResult.items),
+    hasMore: hasNonLiked,
     nextCursor:
       hasNonLiked && likedResult.items.length > 0
         ? likedResult.items[likedResult.items.length - 1].viewId

--- a/src/clips/application/usecases/list-favorite-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-favorite-clips.usecase.spec.ts
@@ -47,6 +47,8 @@ describe('ListFavoriteClipsUseCase', () => {
       likedOnly: true,
     });
     expect(result.items).toHaveLength(3);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
   });
 
   it('커서가 좋아요된 클립이 아니면 NOT_FOUND를 반환한다', async () => {

--- a/src/clips/application/usecases/list-folder-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-folder-clips.usecase.spec.ts
@@ -60,6 +60,7 @@ describe('ListFolderClipsUseCase', () => {
 
     expect(repo.findClips).toHaveBeenCalledTimes(1);
     expect(result.items).toHaveLength(20);
+    expect(result.hasMore).toBe(true);
     expect(result.nextCursor).toBe('clip-20');
   });
 
@@ -106,6 +107,7 @@ describe('ListFolderClipsUseCase', () => {
       'normal-1',
       'normal-2',
     ]);
+    expect(result.hasMore).toBe(false);
     expect(result.nextCursor).toBeNull();
   });
 
@@ -143,6 +145,7 @@ describe('ListFolderClipsUseCase', () => {
       cursor: 'cursor-id',
     });
     expect(result.items).toHaveLength(20);
+    expect(result.hasMore).toBe(true);
     expect(result.nextCursor).toBe('liked-20');
   });
 
@@ -180,6 +183,7 @@ describe('ListFolderClipsUseCase', () => {
       cursor: 'cursor-id',
     });
     expect(result.items.map((item) => item.id)).toEqual(['normal-1']);
+    expect(result.hasMore).toBe(false);
     expect(result.nextCursor).toBeNull();
   });
 

--- a/src/clips/application/usecases/list-recent-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-recent-clips.usecase.spec.ts
@@ -57,6 +57,7 @@ describe('ListRecentClipsUseCase', () => {
       likedOnly: false,
     });
     expect(result.items).toHaveLength(3);
+    expect(result.hasMore).toBe(false);
     expect(result.nextCursor).toBeNull();
   });
 


### PR DESCRIPTION
## Description

폴더 및 최근 클립 목록 조회 응답이 문서화된 계약과 다르게 일부 분기에서 `hasMore`를 누락하던 문제를 수정했습니다. 프론트의 무한 스크롤이 `hasMore`를 기준으로 다음 페이지 여부를 판단하고 있어, `nextCursor`가 있어도 후속 조회가 멈추던 상태를 해소합니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #75

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- `ClipCursorPageOutput`에 `hasMore`를 포함하도록 application 반환 타입을 정리했습니다.
- 폴더/최근 클립 목록 헬퍼가 모든 분기에서 `{ items, hasMore, nextCursor }` 형태를 반환하도록 맞췄습니다.
- 관련 유스케이스 테스트에 `hasMore` 검증을 추가해 응답 계약을 고정했습니다.

## Performance/Scaling

페이지 크기나 조회 전략은 바꾸지 않았고, 기존 커서 기반 조회 동작을 유지한 채 응답 계약만 일관되게 맞췄습니다.

## Testing done

- `pnpm test -- list-folder-clips.usecase.spec.ts list-recent-clips.usecase.spec.ts list-favorite-clips.usecase.spec.ts`
- `pnpm lint`: 미실행
- `pnpm test:e2e`: 미실행

## Additional information

프론트는 `lastPage.hasMore ? lastPage.nextCursor : undefined` 기준으로 다음 페이지 여부를 판단하고 있어, 이번 수정으로 Swagger/DTO 계약과 실제 응답이 일치합니다.