### PR TITLE
#77/feat(auth) : 슬라이딩 세션과 다중 세션 지원

### DIFF
--- a/prisma/migrations/20260622065000_refresh_token_sliding_sessions/migration.sql
+++ b/prisma/migrations/20260622065000_refresh_token_sliding_sessions/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "RefreshToken"
+ADD COLUMN "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN "userAgent" TEXT,
+ADD COLUMN "ipAddress" TEXT,
+ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "RefreshToken" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- DropIndex
+DROP INDEX "RefreshToken_authAccountId_platform_key";
+
+-- CreateIndex
+CREATE INDEX "RefreshToken_authAccountId_platform_idx" ON "RefreshToken"("authAccountId", "platform");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,13 +87,17 @@ model RefreshToken {
 
   expiresAt     DateTime
   revokedAt     DateTime?
+  lastUsedAt    DateTime @default(now())
+  userAgent     String?
+  ipAddress     String?
 
   createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   user          User        @relation(fields: [userId], references: [id])
   authAccount   AuthAccount @relation(fields: [authAccountId], references: [id])
 
-  @@unique([authAccountId, platform])
+  @@index([authAccountId, platform])
   @@index([userId])
 }
 

--- a/src/auth/application/dtos/refresh-access-token-output.dto.ts
+++ b/src/auth/application/dtos/refresh-access-token-output.dto.ts
@@ -1,3 +1,4 @@
 export type RefreshAccessTokenOutput = {
   access_token: string;
+  refresh_token?: string;
 };

--- a/src/auth/application/helpers/auth-result.helper.ts
+++ b/src/auth/application/helpers/auth-result.helper.ts
@@ -1,6 +1,7 @@
 import { AuthContext } from 'src/shared/types/auth-context.type';
 import type { AuthSessionPort } from '../ports/auth-session.port';
 import { AuthSessionOutput } from '../dtos/auth-session-output.dto';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 
 export async function issueAuthResult(
   authSessionPort: AuthSessionPort,
@@ -13,6 +14,7 @@ export async function issueAuthResult(
       profileImageUrl: string | null;
     };
     platform: AuthContext['platform'];
+    metadata?: AuthSessionMetadata;
   },
 ): Promise<AuthSessionOutput> {
   const context: AuthContext = {
@@ -21,7 +23,9 @@ export async function issueAuthResult(
     platform: params.platform,
   };
 
-  const tokens = await authSessionPort.issueTokens(context);
+  const tokens = params.metadata
+    ? await authSessionPort.issueTokens(context, params.metadata)
+    : await authSessionPort.issueTokens(context);
 
   return {
     access_token: tokens.accessToken,

--- a/src/auth/application/ports/auth-session.port.ts
+++ b/src/auth/application/ports/auth-session.port.ts
@@ -1,5 +1,6 @@
 import type { AuthContext } from 'src/shared/types/auth-context.type';
 import type { AuthPlatform } from 'src/shared/types/auth-platform.type';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 
 export const AUTH_SESSION_PORT = Symbol('AUTH_SESSION_PORT');
 
@@ -9,18 +10,31 @@ export type IssuedTokens = {
 };
 
 export type RefreshTokenSession = {
+  sessionId: string;
   tokenHash: string;
   revokedAt: Date | null;
   expiresAt: Date;
 };
 
 export interface AuthSessionPort {
-  issueTokens(context: AuthContext): Promise<IssuedTokens>;
+  issueTokens(
+    context: AuthContext,
+    metadata?: AuthSessionMetadata,
+  ): Promise<IssuedTokens>;
   signAccessToken(context: AuthContext): string;
   findRefreshTokenSession(
-    authAccountId: string,
-    platform: AuthPlatform,
+    sessionId: string,
   ): Promise<RefreshTokenSession | null>;
+  rotateRefreshToken(
+    context: AuthContext & { sessionId: string },
+    expectedTokenHash: string,
+    metadata?: AuthSessionMetadata,
+  ): Promise<IssuedTokens | null>;
+  touchRefreshTokenSession(
+    sessionId: string,
+    metadata?: AuthSessionMetadata,
+  ): Promise<void>;
+  revokeRefreshTokenSession(sessionId: string): Promise<void>;
   revokeRefreshTokens(
     authAccountId: string,
     platform: AuthPlatform,

--- a/src/auth/application/usecases/link-account.usecase.spec.ts
+++ b/src/auth/application/usecases/link-account.usecase.spec.ts
@@ -17,6 +17,9 @@ const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
   signAccessToken: jest.fn(),
   findRefreshTokenSession: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  touchRefreshTokenSession: jest.fn(),
+  revokeRefreshTokenSession: jest.fn(),
   revokeRefreshTokens: jest.fn(),
 });
 

--- a/src/auth/application/usecases/link-account.usecase.ts
+++ b/src/auth/application/usecases/link-account.usecase.ts
@@ -3,6 +3,7 @@ import { AUTH_REPOSITORY } from '../../domain/auth.repository';
 import type { AuthRepository } from '../../domain/auth.repository';
 import { AUTH_SESSION_PORT } from '../ports/auth-session.port';
 import type { AuthSessionPort } from '../ports/auth-session.port';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 import { AuthError } from '../errors/auth.error';
 import { AuthSessionOutput } from '../dtos/auth-session-output.dto';
 import { OAuthUser } from '../../domain/auth.types';
@@ -21,7 +22,10 @@ export class LinkAccountUseCase {
     private readonly authSessionPort: AuthSessionPort,
   ) {}
 
-  async execute(oauthUser: OAuthUser): Promise<AuthSessionOutput> {
+  async execute(
+    oauthUser: OAuthUser,
+    metadata?: AuthSessionMetadata,
+  ): Promise<AuthSessionOutput> {
     if (!oauthUser.currentUserId) {
       throw new AuthError('FORBIDDEN', '로그인이 필요합니다.');
     }
@@ -54,6 +58,7 @@ export class LinkAccountUseCase {
       userId: newAccount.userId,
       account: newAccount,
       platform: oauthUser.platform,
+      metadata,
     });
   }
 }

--- a/src/auth/application/usecases/logout.usecase.spec.ts
+++ b/src/auth/application/usecases/logout.usecase.spec.ts
@@ -6,11 +6,28 @@ const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
   signAccessToken: jest.fn(),
   findRefreshTokenSession: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  touchRefreshTokenSession: jest.fn(),
+  revokeRefreshTokenSession: jest.fn(),
   revokeRefreshTokens: jest.fn(),
 });
 
 describe('LogoutUseCase', () => {
-  it('리프레시 토큰을 폐기하고 성공을 반환한다', async () => {
+  it('현재 세션 ID가 있으면 해당 리프레시 토큰 세션만 폐기한다', async () => {
+    const sessionPort = createSessionPort();
+    sessionPort.revokeRefreshTokenSession.mockResolvedValue();
+
+    const usecase = new LogoutUseCase(sessionPort);
+    const result = await usecase.execute('account-id', 'WEB', 'session-id');
+
+    expect(sessionPort.revokeRefreshTokenSession).toHaveBeenCalledWith(
+      'session-id',
+    );
+    expect(sessionPort.revokeRefreshTokens).not.toHaveBeenCalled();
+    expect(result).toEqual({ success: true });
+  });
+
+  it('세션 ID가 없으면 기존 플랫폼 세션 폐기 방식으로 폴백한다', async () => {
     const sessionPort = createSessionPort();
     sessionPort.revokeRefreshTokens.mockResolvedValue();
 
@@ -21,6 +38,7 @@ describe('LogoutUseCase', () => {
       'account-id',
       'WEB',
     );
+    expect(sessionPort.revokeRefreshTokenSession).not.toHaveBeenCalled();
     expect(result).toEqual({ success: true });
   });
 });

--- a/src/auth/application/usecases/logout.usecase.ts
+++ b/src/auth/application/usecases/logout.usecase.ts
@@ -14,8 +14,13 @@ export class LogoutUseCase {
   async execute(
     authAccountId: string,
     platform: AuthPlatform,
+    sessionId?: string,
   ): Promise<LogoutOutput> {
-    await this.authSessionPort.revokeRefreshTokens(authAccountId, platform);
+    if (sessionId) {
+      await this.authSessionPort.revokeRefreshTokenSession(sessionId);
+    } else {
+      await this.authSessionPort.revokeRefreshTokens(authAccountId, platform);
+    }
 
     return { success: true };
   }

--- a/src/auth/application/usecases/refresh-access-token.usecase.spec.ts
+++ b/src/auth/application/usecases/refresh-access-token.usecase.spec.ts
@@ -7,11 +7,21 @@ const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
   signAccessToken: jest.fn(),
   findRefreshTokenSession: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  touchRefreshTokenSession: jest.fn(),
+  revokeRefreshTokenSession: jest.fn(),
   revokeRefreshTokens: jest.fn(),
 });
 
 const createHashToken = (token: string): string =>
   createHash('sha256').update(token).digest('hex');
+
+const authContext = {
+  userId: 'user-id',
+  accountId: 'account-id',
+  platform: 'WEB' as const,
+  sessionId: 'session-id',
+};
 
 describe('RefreshAccessTokenUseCase', () => {
   it('세션이 없으면 UNAUTHORIZED 오류를 반환한다', async () => {
@@ -21,11 +31,12 @@ describe('RefreshAccessTokenUseCase', () => {
     const usecase = new RefreshAccessTokenUseCase(sessionPort);
 
     await expect(
-      usecase.execute(
-        { userId: 'user-id', accountId: 'account-id', platform: 'WEB' },
-        'refresh-token',
-      ),
+      usecase.execute(authContext, 'refresh-token'),
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+
+    expect(sessionPort.findRefreshTokenSession).toHaveBeenCalledWith(
+      'session-id',
+    );
   });
 
   it('폐기된 세션이면 UNAUTHORIZED 오류를 반환한다', async () => {
@@ -34,15 +45,13 @@ describe('RefreshAccessTokenUseCase', () => {
       tokenHash: createHashToken('refresh-token'),
       revokedAt: new Date(),
       expiresAt: new Date(Date.now() + 1000 * 60),
+      sessionId: 'session-id',
     });
 
     const usecase = new RefreshAccessTokenUseCase(sessionPort);
 
     await expect(
-      usecase.execute(
-        { userId: 'user-id', accountId: 'account-id', platform: 'WEB' },
-        'refresh-token',
-      ),
+      usecase.execute(authContext, 'refresh-token'),
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
@@ -52,15 +61,13 @@ describe('RefreshAccessTokenUseCase', () => {
       tokenHash: createHashToken('refresh-token'),
       revokedAt: null,
       expiresAt: new Date(Date.now() - 1000 * 60),
+      sessionId: 'session-id',
     });
 
     const usecase = new RefreshAccessTokenUseCase(sessionPort);
 
     await expect(
-      usecase.execute(
-        { userId: 'user-id', accountId: 'account-id', platform: 'WEB' },
-        'refresh-token',
-      ),
+      usecase.execute(authContext, 'refresh-token'),
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
@@ -70,8 +77,93 @@ describe('RefreshAccessTokenUseCase', () => {
       tokenHash: createHashToken('stored-token'),
       revokedAt: null,
       expiresAt: new Date(Date.now() + 1000 * 60),
+      sessionId: 'session-id',
     });
 
+    const usecase = new RefreshAccessTokenUseCase(sessionPort);
+
+    await expect(
+      usecase.execute(authContext, 'refresh-token'),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('임계 구간 밖이면 액세스 토큰만 발급하고 세션 사용 시각을 갱신한다', async () => {
+    const sessionPort = createSessionPort();
+    sessionPort.findRefreshTokenSession.mockResolvedValue({
+      tokenHash: createHashToken('refresh-token'),
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+      sessionId: 'session-id',
+    });
+    sessionPort.signAccessToken.mockReturnValue('access-token');
+    sessionPort.touchRefreshTokenSession.mockResolvedValue();
+
+    const usecase = new RefreshAccessTokenUseCase(sessionPort);
+    const result = await usecase.execute(authContext, 'refresh-token', {
+      userAgent: 'Mozilla/5.0',
+      ipAddress: '127.0.0.1',
+    });
+
+    expect(sessionPort.signAccessToken).toHaveBeenCalledWith(authContext);
+    expect(sessionPort.touchRefreshTokenSession).toHaveBeenCalledWith(
+      'session-id',
+      {
+        userAgent: 'Mozilla/5.0',
+        ipAddress: '127.0.0.1',
+      },
+    );
+    expect(sessionPort.rotateRefreshToken).not.toHaveBeenCalled();
+    expect(result).toEqual({ access_token: 'access-token' });
+  });
+
+  it('임계 구간 안이면 액세스 토큰과 리프레시 토큰을 함께 rotation한다', async () => {
+    const sessionPort = createSessionPort();
+    sessionPort.findRefreshTokenSession.mockResolvedValue({
+      tokenHash: createHashToken('refresh-token'),
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      sessionId: 'session-id',
+    });
+    sessionPort.rotateRefreshToken.mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+    });
+
+    const usecase = new RefreshAccessTokenUseCase(sessionPort);
+    const result = await usecase.execute(authContext, 'refresh-token');
+
+    expect(sessionPort.rotateRefreshToken).toHaveBeenCalledWith(
+      authContext,
+      createHashToken('refresh-token'),
+      undefined,
+    );
+    expect(sessionPort.signAccessToken).not.toHaveBeenCalled();
+    expect(sessionPort.touchRefreshTokenSession).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+    });
+  });
+
+  it('rotation 중 저장된 토큰 해시가 바뀌면 UNAUTHORIZED 오류를 반환한다', async () => {
+    const sessionPort = createSessionPort();
+    sessionPort.findRefreshTokenSession.mockResolvedValue({
+      tokenHash: createHashToken('refresh-token'),
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      sessionId: 'session-id',
+    });
+    sessionPort.rotateRefreshToken.mockResolvedValue(null);
+
+    const usecase = new RefreshAccessTokenUseCase(sessionPort);
+
+    await expect(
+      usecase.execute(authContext, 'refresh-token'),
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('세션 ID가 없으면 UNAUTHORIZED 오류를 반환한다', async () => {
+    const sessionPort = createSessionPort();
     const usecase = new RefreshAccessTokenUseCase(sessionPort);
 
     await expect(
@@ -80,28 +172,7 @@ describe('RefreshAccessTokenUseCase', () => {
         'refresh-token',
       ),
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-  });
 
-  it('정상적인 요청이면 액세스 토큰을 발급한다', async () => {
-    const sessionPort = createSessionPort();
-    sessionPort.findRefreshTokenSession.mockResolvedValue({
-      tokenHash: createHashToken('refresh-token'),
-      revokedAt: null,
-      expiresAt: new Date(Date.now() + 1000 * 60),
-    });
-    sessionPort.signAccessToken.mockReturnValue('access-token');
-
-    const usecase = new RefreshAccessTokenUseCase(sessionPort);
-    const result = await usecase.execute(
-      { userId: 'user-id', accountId: 'account-id', platform: 'WEB' },
-      'refresh-token',
-    );
-
-    expect(sessionPort.signAccessToken).toHaveBeenCalledWith({
-      userId: 'user-id',
-      accountId: 'account-id',
-      platform: 'WEB',
-    });
-    expect(result).toEqual({ access_token: 'access-token' });
+    expect(sessionPort.findRefreshTokenSession).not.toHaveBeenCalled();
   });
 });

--- a/src/auth/application/usecases/refresh-access-token.usecase.ts
+++ b/src/auth/application/usecases/refresh-access-token.usecase.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { AuthContext } from 'src/shared/types/auth-context.type';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 import { AUTH_SESSION_PORT } from '../ports/auth-session.port';
 import type { AuthSessionPort } from '../ports/auth-session.port';
 import { RefreshAccessTokenOutput } from '../dtos/refresh-access-token-output.dto';
@@ -7,6 +8,9 @@ import {
   assertRefreshTokenMatches,
   assertRefreshTokenSession,
 } from '../helpers/refresh-token.helper';
+import { AuthError } from '../errors/auth.error';
+
+const REFRESH_TOKEN_ROTATION_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class RefreshAccessTokenUseCase {
@@ -18,16 +22,49 @@ export class RefreshAccessTokenUseCase {
   async execute(
     context: AuthContext,
     refreshToken: string,
+    metadata?: AuthSessionMetadata,
   ): Promise<RefreshAccessTokenOutput> {
-    const { accountId, platform } = context;
+    if (!context.sessionId) {
+      throw new AuthError('UNAUTHORIZED', '리프레쉬 세션이 존재하지 않습니다.');
+    }
 
     const session = assertRefreshTokenSession(
-      await this.authSessionPort.findRefreshTokenSession(accountId, platform),
+      await this.authSessionPort.findRefreshTokenSession(context.sessionId),
     );
     assertRefreshTokenMatches(refreshToken, session.tokenHash);
 
+    if (shouldRotateRefreshToken(session.expiresAt)) {
+      const tokens = await this.authSessionPort.rotateRefreshToken(
+        { ...context, sessionId: context.sessionId },
+        session.tokenHash,
+        metadata,
+      );
+
+      if (!tokens) {
+        throw new AuthError(
+          'UNAUTHORIZED',
+          '리프레쉬 토큰이 일치하지 않습니다.',
+        );
+      }
+
+      return {
+        access_token: tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+      };
+    }
+
     const accessToken = this.authSessionPort.signAccessToken(context);
+    await this.authSessionPort.touchRefreshTokenSession(
+      context.sessionId,
+      metadata,
+    );
 
     return { access_token: accessToken };
   }
+}
+
+function shouldRotateRefreshToken(expiresAt: Date): boolean {
+  return (
+    expiresAt.getTime() - Date.now() <= REFRESH_TOKEN_ROTATION_THRESHOLD_MS
+  );
 }

--- a/src/auth/application/usecases/sign-in.usecase.spec.ts
+++ b/src/auth/application/usecases/sign-in.usecase.spec.ts
@@ -17,6 +17,9 @@ const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
   signAccessToken: jest.fn(),
   findRefreshTokenSession: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  touchRefreshTokenSession: jest.fn(),
+  revokeRefreshTokenSession: jest.fn(),
   revokeRefreshTokens: jest.fn(),
 });
 

--- a/src/auth/application/usecases/sign-in.usecase.ts
+++ b/src/auth/application/usecases/sign-in.usecase.ts
@@ -3,6 +3,7 @@ import { AUTH_REPOSITORY } from '../../domain/auth.repository';
 import type { AuthRepository } from '../../domain/auth.repository';
 import { AUTH_SESSION_PORT } from '../ports/auth-session.port';
 import type { AuthSessionPort } from '../ports/auth-session.port';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 import { AuthError } from '../errors/auth.error';
 import { AuthSessionOutput } from '../dtos/auth-session-output.dto';
 import { OAuthUser } from '../../domain/auth.types';
@@ -21,7 +22,10 @@ export class SignInUseCase {
     private readonly authSessionPort: AuthSessionPort,
   ) {}
 
-  async execute(oauthUser: OAuthUser): Promise<AuthSessionOutput> {
+  async execute(
+    oauthUser: OAuthUser,
+    metadata?: AuthSessionMetadata,
+  ): Promise<AuthSessionOutput> {
     const email = requireOAuthEmail(oauthUser);
 
     const existingAccount = await this.authRepository.findAccountByProvider(
@@ -34,6 +38,7 @@ export class SignInUseCase {
         userId: existingAccount.userId,
         account: existingAccount,
         platform: oauthUser.platform,
+        metadata,
       });
     }
 
@@ -55,6 +60,7 @@ export class SignInUseCase {
       userId: newAccount.userId,
       account: newAccount,
       platform: oauthUser.platform,
+      metadata,
     });
   }
 }

--- a/src/auth/application/usecases/switch-user.usecase.spec.ts
+++ b/src/auth/application/usecases/switch-user.usecase.spec.ts
@@ -16,6 +16,9 @@ const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
   signAccessToken: jest.fn(),
   findRefreshTokenSession: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  touchRefreshTokenSession: jest.fn(),
+  revokeRefreshTokenSession: jest.fn(),
   revokeRefreshTokens: jest.fn(),
 });
 

--- a/src/auth/application/usecases/switch-user.usecase.ts
+++ b/src/auth/application/usecases/switch-user.usecase.ts
@@ -3,6 +3,7 @@ import { AUTH_REPOSITORY } from '../../domain/auth.repository';
 import type { AuthRepository } from '../../domain/auth.repository';
 import { AUTH_SESSION_PORT } from '../ports/auth-session.port';
 import type { AuthSessionPort } from '../ports/auth-session.port';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 import { AuthError } from '../errors/auth.error';
 import { AuthSessionOutput } from '../dtos/auth-session-output.dto';
 import { AuthPlatform } from 'src/shared/types/auth-platform.type';
@@ -21,6 +22,7 @@ export class SwitchUserUseCase {
     currentUserId: string,
     targetAuthAccountId: string,
     platform: AuthPlatform,
+    metadata?: AuthSessionMetadata,
   ): Promise<AuthSessionOutput> {
     const targetAccount =
       await this.authRepository.findAccountById(targetAuthAccountId);
@@ -37,6 +39,7 @@ export class SwitchUserUseCase {
       userId: targetAccount.userId,
       account: targetAccount,
       platform,
+      metadata,
     });
   }
 }

--- a/src/auth/application/usecases/test-admin-login.usecase.spec.ts
+++ b/src/auth/application/usecases/test-admin-login.usecase.spec.ts
@@ -16,6 +16,9 @@ const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
   signAccessToken: jest.fn(),
   findRefreshTokenSession: jest.fn(),
+  rotateRefreshToken: jest.fn(),
+  touchRefreshTokenSession: jest.fn(),
+  revokeRefreshTokenSession: jest.fn(),
   revokeRefreshTokens: jest.fn(),
 });
 

--- a/src/auth/application/usecases/test-admin-login.usecase.ts
+++ b/src/auth/application/usecases/test-admin-login.usecase.ts
@@ -3,6 +3,7 @@ import { AUTH_REPOSITORY } from '../../domain/auth.repository';
 import type { AuthRepository } from '../../domain/auth.repository';
 import { AUTH_SESSION_PORT } from '../ports/auth-session.port';
 import type { AuthSessionPort } from '../ports/auth-session.port';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 import { AuthSessionOutput } from '../dtos/auth-session-output.dto';
 import { TestAdminLoginInput } from '../dtos/test-admin-login-input.dto';
 import { issueAuthResult } from '../helpers/auth-result.helper';
@@ -19,7 +20,10 @@ export class TestAdminLoginUseCase {
     private readonly authSessionPort: AuthSessionPort,
   ) {}
 
-  async execute(input: TestAdminLoginInput): Promise<AuthSessionOutput> {
+  async execute(
+    input: TestAdminLoginInput,
+    metadata?: AuthSessionMetadata,
+  ): Promise<AuthSessionOutput> {
     const existingAccount = await this.authRepository.findAccountByProvider(
       TEST_ADMIN_PROVIDER,
       TEST_ADMIN_PROVIDER_USER_ID,
@@ -30,6 +34,7 @@ export class TestAdminLoginUseCase {
         userId: existingAccount.userId,
         account: existingAccount,
         platform: input.platform,
+        metadata,
       });
     }
 
@@ -58,6 +63,7 @@ export class TestAdminLoginUseCase {
       userId: account.userId,
       account,
       platform: input.platform,
+      metadata,
     });
   }
 }

--- a/src/auth/infrastructure/jwt-auth-session.port.ts
+++ b/src/auth/infrastructure/jwt-auth-session.port.ts
@@ -2,9 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Platform } from '@prisma/client';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import type { AuthContext } from 'src/shared/types/auth-context.type';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 import type {
   AuthSessionPort,
   IssuedTokens,
@@ -20,40 +21,28 @@ export class JwtAuthSessionPort implements AuthSessionPort {
     private readonly config: ConfigService,
   ) {}
 
-  async issueTokens(context: AuthContext): Promise<IssuedTokens> {
-    const accessToken = this.signAccessToken(context);
-    const refreshToken = this.signRefreshToken(context);
+  async issueTokens(
+    context: AuthContext,
+    metadata?: AuthSessionMetadata,
+  ): Promise<IssuedTokens> {
+    const sessionContext = {
+      ...context,
+      sessionId: randomUUID(),
+    };
+    const accessToken = this.signAccessToken(sessionContext);
+    const refreshToken = this.signRefreshToken(sessionContext);
     const tokenHash = createHash('sha256').update(refreshToken).digest('hex');
 
-    const verified = await this.jwtService.verifyAsync<{ exp: number }>(
-      refreshToken,
-      {
-        secret: this.config.getOrThrow<string>('JWT_REFRESH_SECRET'),
-        audience: 'refresh',
-        issuer: 'easy-clip',
-      },
-    );
-
-    const expiresAt = new Date(verified.exp * 1000);
-
-    await this.prisma.refreshToken.upsert({
-      where: {
-        authAccountId_platform: {
-          authAccountId: context.accountId,
-          platform: context.platform as Platform,
-        },
-      },
-      update: {
+    await this.prisma.refreshToken.create({
+      data: {
+        id: sessionContext.sessionId,
+        userId: sessionContext.userId,
+        authAccountId: sessionContext.accountId,
+        platform: sessionContext.platform as Platform,
         tokenHash,
-        revokedAt: null,
-        expiresAt,
-      },
-      create: {
-        userId: context.userId,
-        authAccountId: context.accountId,
-        platform: context.platform as Platform,
-        tokenHash,
-        expiresAt,
+        expiresAt: await this.resolveRefreshTokenExpiresAt(refreshToken),
+        lastUsedAt: new Date(),
+        ...this.toSessionMetadataUpdate(metadata),
       },
     });
 
@@ -70,24 +59,86 @@ export class JwtAuthSessionPort implements AuthSessionPort {
   }
 
   async findRefreshTokenSession(
-    authAccountId: string,
-    platform: AuthPlatform,
+    sessionId: string,
   ): Promise<RefreshTokenSession | null> {
     const session = await this.prisma.refreshToken.findUnique({
-      where: {
-        authAccountId_platform: {
-          authAccountId,
-          platform: platform as Platform,
-        },
-      },
+      where: { id: sessionId },
       select: {
+        id: true,
         tokenHash: true,
         revokedAt: true,
         expiresAt: true,
       },
     });
 
-    return session ?? null;
+    if (!session) {
+      return null;
+    }
+
+    return {
+      sessionId: session.id,
+      tokenHash: session.tokenHash,
+      revokedAt: session.revokedAt,
+      expiresAt: session.expiresAt,
+    };
+  }
+
+  async rotateRefreshToken(
+    context: AuthContext & { sessionId: string },
+    expectedTokenHash: string,
+    metadata?: AuthSessionMetadata,
+  ): Promise<IssuedTokens | null> {
+    const accessToken = this.signAccessToken(context);
+    const refreshToken = this.signRefreshToken(context);
+    const tokenHash = createHash('sha256').update(refreshToken).digest('hex');
+
+    const result = await this.prisma.refreshToken.updateMany({
+      where: {
+        id: context.sessionId,
+        tokenHash: expectedTokenHash,
+        revokedAt: null,
+      },
+      data: {
+        tokenHash,
+        expiresAt: await this.resolveRefreshTokenExpiresAt(refreshToken),
+        lastUsedAt: new Date(),
+        ...this.toSessionMetadataUpdate(metadata),
+      },
+    });
+
+    if (result.count === 0) {
+      return null;
+    }
+
+    return { accessToken, refreshToken };
+  }
+
+  async touchRefreshTokenSession(
+    sessionId: string,
+    metadata?: AuthSessionMetadata,
+  ): Promise<void> {
+    await this.prisma.refreshToken.updateMany({
+      where: {
+        id: sessionId,
+        revokedAt: null,
+      },
+      data: {
+        lastUsedAt: new Date(),
+        ...this.toSessionMetadataUpdate(metadata),
+      },
+    });
+  }
+
+  async revokeRefreshTokenSession(sessionId: string): Promise<void> {
+    await this.prisma.refreshToken.updateMany({
+      where: {
+        id: sessionId,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
   }
 
   async revokeRefreshTokens(
@@ -120,6 +171,29 @@ export class JwtAuthSessionPort implements AuthSessionPort {
       sub: context.userId,
       accountId: context.accountId,
       platform: context.platform,
+      ...(context.sessionId ? { sid: context.sessionId } : {}),
+    };
+  }
+
+  private async resolveRefreshTokenExpiresAt(
+    refreshToken: string,
+  ): Promise<Date> {
+    const verified = await this.jwtService.verifyAsync<{ exp: number }>(
+      refreshToken,
+      {
+        secret: this.config.getOrThrow<string>('JWT_REFRESH_SECRET'),
+        audience: 'refresh',
+        issuer: 'easy-clip',
+      },
+    );
+
+    return new Date(verified.exp * 1000);
+  }
+
+  private toSessionMetadataUpdate(metadata?: AuthSessionMetadata) {
+    return {
+      ...(metadata?.userAgent ? { userAgent: metadata.userAgent } : {}),
+      ...(metadata?.ipAddress ? { ipAddress: metadata.ipAddress } : {}),
     };
   }
 }

--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -20,8 +20,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { Request as ExpressRequest } from 'express';
-import type { Response } from 'express';
+import type { Request as ExpressRequest, Response } from 'express';
 import { JwtAccessGuard } from 'src/shared/presentation/guards/jwt-access.guard';
 import { AuthContext } from 'src/shared/types/auth-context.type';
 import { ApplicationExceptionFilter } from 'src/shared/presentation/filters/application-exception.filter';
@@ -43,6 +42,7 @@ import { ErrorResponseDto } from 'src/shared/presentation/dtos/error-response.dt
 import { TestAdminLoginDto } from './dtos/test-admin-login.dto';
 import {
   clearAuthCookies,
+  extractAuthSessionMetadata,
   resolveOAuthSuccessRedirectUrl,
   setAccessTokenCookie,
   setAuthCookies,
@@ -106,7 +106,7 @@ export class AuthController {
     @Request() req: OAuthRequest,
     @Res({ passthrough: true }) response: Response,
   ): Promise<void> {
-    await this.completeOAuthCallback(req.user, response);
+    await this.completeOAuthCallback(req, response);
   }
 
   /* ======================================================
@@ -149,7 +149,7 @@ export class AuthController {
     @Request() req: OAuthRequest,
     @Res({ passthrough: true }) response: Response,
   ): Promise<void> {
-    await this.completeOAuthCallback(req.user, response);
+    await this.completeOAuthCallback(req, response);
   }
 
   @Post('test/admin-login')
@@ -160,15 +160,19 @@ export class AuthController {
     type: AuthSignInResponseDto,
   })
   async testAdminLogin(
+    @Request() request: ExpressRequest,
     @Body() dto: TestAdminLoginDto = {},
     @Res({ passthrough: true }) response: Response,
   ) {
-    const authSession = await this.testAdminLoginUseCase.execute({
-      email: 'admin@easyclip.local',
-      displayName: 'Test Admin',
-      avatarUrl: null,
-      platform: dto.platform ?? 'WEB',
-    });
+    const authSession = await this.testAdminLoginUseCase.execute(
+      {
+        email: 'admin@easyclip.local',
+        displayName: 'Test Admin',
+        avatarUrl: null,
+        platform: dto.platform ?? 'WEB',
+      },
+      extractAuthSessionMetadata(request),
+    );
 
     setAuthCookies(response, this.configService, authSession);
 
@@ -193,7 +197,7 @@ export class AuthController {
     type: ErrorResponseDto,
   })
   async switchUser(
-    @Request() req: { user: AuthContext },
+    @Request() req: ExpressRequest & { user: AuthContext },
     @Body() switchUserDto: SwitchUserDto,
     @Res({ passthrough: true }) response: Response,
   ) {
@@ -201,6 +205,7 @@ export class AuthController {
       req.user.userId,
       switchUserDto.authAccountId,
       req.user.platform,
+      extractAuthSessionMetadata(req),
     );
 
     setAuthCookies(response, this.configService, authSession);
@@ -210,7 +215,7 @@ export class AuthController {
 
   @UseGuards(JwtRefreshGuard)
   @Post('refresh')
-  @ApiBearerAuth('access-token')
+  @ApiBearerAuth('refresh-token')
   @ApiOperation({ summary: '액세스 토큰 재발급' })
   @ApiOkResponse({
     description: '새 액세스 토큰을 반환합니다.',
@@ -222,7 +227,7 @@ export class AuthController {
   })
   async refresh(
     @Request()
-    req: {
+    req: ExpressRequest & {
       user: AuthContext;
       refreshToken: string;
     },
@@ -231,9 +236,17 @@ export class AuthController {
     const result = await this.refreshAccessTokenUseCase.execute(
       req.user,
       req.refreshToken,
+      extractAuthSessionMetadata(req),
     );
 
-    setAccessTokenCookie(response, this.configService, result.access_token);
+    if (result.refresh_token) {
+      setAuthCookies(response, this.configService, {
+        access_token: result.access_token,
+        refresh_token: result.refresh_token,
+      });
+    } else {
+      setAccessTokenCookie(response, this.configService, result.access_token);
+    }
 
     return result;
   }
@@ -241,9 +254,9 @@ export class AuthController {
   @UseGuards(JwtAccessGuard)
   @Post('logout')
   @ApiBearerAuth('access-token')
-  @ApiOperation({ summary: '현재 플랫폼 로그아웃' })
+  @ApiOperation({ summary: '현재 세션 로그아웃' })
   @ApiOkResponse({
-    description: '현재 플랫폼의 리프레시 토큰 세션을 만료시킵니다.',
+    description: '현재 리프레시 토큰 세션을 만료시킵니다.',
     type: LogoutResponseDto,
   })
   @ApiUnauthorizedResponse({
@@ -251,12 +264,13 @@ export class AuthController {
     type: ErrorResponseDto,
   })
   async logout(
-    @Request() req: { user: AuthContext },
+    @Request() req: ExpressRequest & { user: AuthContext },
     @Res({ passthrough: true }) response: Response,
   ) {
     const result = await this.logoutUseCase.execute(
       req.user.accountId,
       req.user.platform,
+      req.user.sessionId,
     );
 
     clearAuthCookies(response, this.configService);
@@ -264,19 +278,21 @@ export class AuthController {
     return result;
   }
 
-  private handleOAuthCallback(oauthUser: OAuthUser) {
+  private handleOAuthCallback(oauthUser: OAuthUser, request: ExpressRequest) {
+    const metadata = extractAuthSessionMetadata(request);
+
     if (oauthUser.mode === 'link') {
-      return this.linkAccountUseCase.execute(oauthUser);
+      return this.linkAccountUseCase.execute(oauthUser, metadata);
     }
 
-    return this.signInUseCase.execute(oauthUser);
+    return this.signInUseCase.execute(oauthUser, metadata);
   }
 
   private async completeOAuthCallback(
-    oauthUser: OAuthUser,
+    request: OAuthRequest,
     response: Response,
   ): Promise<void> {
-    const authSession = await this.handleOAuthCallback(oauthUser);
+    const authSession = await this.handleOAuthCallback(request.user, request);
 
     setAuthCookies(response, this.configService, authSession);
     response.redirect(

--- a/src/auth/presentation/dtos/auth-response.dto.ts
+++ b/src/auth/presentation/dtos/auth-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class AuthUserResponseDto {
   @ApiProperty({ example: 'cmauthuser123' })
@@ -28,6 +28,13 @@ export class AuthSignInResponseDto {
 export class RefreshAccessTokenResponseDto {
   @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
   access_token: string;
+
+  @ApiPropertyOptional({
+    example: 'refresh-token-value',
+    description:
+      '리프레시 토큰 만료가 24시간 이내로 남아 rotation이 발생한 경우에만 반환됩니다.',
+  })
+  refresh_token?: string;
 }
 
 export class LogoutResponseDto {

--- a/src/auth/presentation/guards/jwt-refresh-token.guard.ts
+++ b/src/auth/presentation/guards/jwt-refresh-token.guard.ts
@@ -15,6 +15,7 @@ type JwtClaims = {
   sub: string;
   accountId: string;
   platform: AuthPlatform;
+  sid?: string;
 };
 
 @Injectable()
@@ -43,6 +44,7 @@ export class JwtRefreshGuard implements CanActivate {
         userId: payload.sub,
         accountId: payload.accountId,
         platform: payload.platform,
+        sessionId: payload.sid,
       };
 
       request['user'] = authContext;

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,16 @@ async function bootstrap() {
       },
       'access-token',
     )
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description:
+          'JWT refresh token을 입력하세요. 쿠키 인증 환경에서는 easy_clip_refresh_token 쿠키가 우선 사용됩니다.',
+      },
+      'refresh-token',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, swaggerConfig);

--- a/src/shared/presentation/guards/jwt-access.guard.ts
+++ b/src/shared/presentation/guards/jwt-access.guard.ts
@@ -15,6 +15,7 @@ type JwtClaims = {
   sub: string;
   accountId: string;
   platform: AuthPlatform;
+  sid?: string;
 };
 
 @Injectable()
@@ -43,6 +44,7 @@ export class JwtAccessGuard implements CanActivate {
         userId: payload.sub,
         accountId: payload.accountId,
         platform: payload.platform,
+        sessionId: payload.sid,
       };
 
       request['user'] = authContext;

--- a/src/shared/presentation/helpers/auth-cookie.helper.ts
+++ b/src/shared/presentation/helpers/auth-cookie.helper.ts
@@ -1,5 +1,6 @@
 import type { CookieOptions, Request, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
+import type { AuthSessionMetadata } from 'src/shared/types/auth-session-metadata.type';
 
 const ACCESS_TOKEN_COOKIE_NAME = 'easy_clip_access_token';
 const REFRESH_TOKEN_COOKIE_NAME = 'easy_clip_refresh_token';
@@ -60,6 +61,15 @@ export function extractRefreshToken(request: Request): string | undefined {
   return extractCookieToken(request, 'refresh') ?? extractBearerToken(request);
 }
 
+export function extractAuthSessionMetadata(
+  request: Request,
+): AuthSessionMetadata {
+  return {
+    userAgent: request.headers['user-agent'],
+    ipAddress: resolveClientIp(request),
+  };
+}
+
 export function resolveOAuthSuccessRedirectUrl(
   config: ConfigService,
   userId: string,
@@ -72,6 +82,16 @@ export function resolveOAuthSuccessRedirectUrl(
 function extractBearerToken(request: Request): string | undefined {
   const [type, token] = request.headers.authorization?.split(' ') ?? [];
   return type === 'Bearer' ? token : undefined;
+}
+
+function resolveClientIp(request: Request): string | undefined {
+  const forwardedFor = request.headers['x-forwarded-for'];
+
+  if (Array.isArray(forwardedFor)) {
+    return forwardedFor[0]?.split(',')[0]?.trim();
+  }
+
+  return forwardedFor?.split(',')[0]?.trim() || request.ip;
 }
 
 function extractCookieToken(

--- a/src/shared/types/auth-context.type.ts
+++ b/src/shared/types/auth-context.type.ts
@@ -4,4 +4,5 @@ export type AuthContext = {
   userId: string;
   accountId: string;
   platform: AuthPlatform;
+  sessionId?: string;
 };

--- a/src/shared/types/auth-session-metadata.type.ts
+++ b/src/shared/types/auth-session-metadata.type.ts
@@ -1,0 +1,4 @@
+export type AuthSessionMetadata = {
+  userAgent?: string;
+  ipAddress?: string;
+};


### PR DESCRIPTION
## Description

리프레시 토큰 기반 세션을 다중 세션 구조로 바꾸고, 만료 24시간 이내에만 refresh token rotation이 발생하는 슬라이딩 세션 정책을 구현했습니다.

기존에는 `authAccountId + platform` 기준 단일 refresh 세션만 저장되어 같은 플랫폼의 여러 브라우저/기기 동시 로그인이 어렵고, `/auth/refresh`에서도 access token만 재발급되어 활동 중 세션 연장이 되지 않았습니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #77

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `RefreshToken`의 `authAccountId + platform` unique 제약을 제거하고 다중 세션 인덱스로 변경했습니다.
- refresh 세션 ID를 JWT payload의 `sid`로 포함해 현재 세션을 식별하도록 했습니다.
- `/auth/refresh`에서 refresh token 만료가 24시간 이내면 access/refresh token을 함께 rotation하고, 그 밖에서는 access token만 재발급합니다.
- rotation 시 `sessionId + 기존 tokenHash + revokedAt null` 조건으로 원자적 업데이트를 수행해 이전 refresh token 재사용과 동시 rotation을 방어합니다.
- 로그아웃은 `sid`가 있으면 현재 세션만 만료하도록 조정했습니다.
- 세션 메타데이터로 `lastUsedAt`, `userAgent`, `ipAddress`를 저장합니다.
- Swagger Authorize에 `refresh-token` bearer 스키마를 추가하고 `/auth/refresh`가 이를 사용하도록 문서화했습니다.

## Performance/Scaling

- refresh 세션 조회는 세션 ID 단건 조회입니다.
- 계정/플랫폼별 세션 조회를 고려해 `authAccountId + platform` 인덱스를 유지했습니다.
- refresh rotation은 임계 구간 안에서만 발생하므로 매 refresh 요청마다 refresh token을 갱신하지 않습니다.

## Testing done

- `pnpm lint`
- `pnpm build`
- `pnpm test`
- 수동 테스트: refresh token 만료 시각을 24시간 임계 구간 안/밖으로 조정해 `/auth/refresh` 응답의 `refresh_token` 포함 여부와 rotation 동작 확인

## Additional information

- Prisma migration 포함: `20260622065000_refresh_token_sliding_sessions`
- 기존에 발급된 `sid` 없는 refresh token은 새 refresh 흐름에서 세션 식별이 불가능하므로, 배포 후 기존 로그인 사용자는 재로그인이 필요할 수 있습니다.