### PR TITLE
#80/fix(chore) : 로컬 DB 포트 노출 제한

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,10 +3,11 @@ services:
     image: postgres:18
     container_name: easyclip-postgres
     ports:
-      - '5432:5432'
+      - '127.0.0.1:5432:5432'
+    env_file:
+      - ../.env.local
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: app_db
     volumes:
       - postgres-data:/var/lib/postgresql


### PR DESCRIPTION
## Description

로컬 개발용 Postgres 컨테이너가 외부 네트워크에 노출되지 않도록 Docker 포트 바인딩을 localhost로 제한합니다. DB 비밀번호는 compose 파일에 하드코딩하지 않고 로컬 환경 파일에서 주입되도록 변경했습니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)

## Linked tickets and other PRs

- Closes #80

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `docker/docker-compose.yml`의 Postgres 포트 바인딩을 `127.0.0.1:5432:5432`로 제한했습니다.
- `POSTGRES_PASSWORD` 하드코딩을 제거하고 `../.env.local`을 `env_file`로 사용하도록 변경했습니다.

## Performance/Scaling

로컬 개발 환경 보안 설정 변경이며 런타임 성능 영향은 없습니다.

## Testing done

- `docker compose -f docker/docker-compose.yml config --services`
- `pnpm prisma migrate status`
- `pnpm lint`
- `pnpm test --runInBand`
- `pnpm test:e2e`: 미실행 (Docker compose 설정 변경으로 e2e 영향 없음)

## Additional information

기존 감염된 로컬 DB 컨테이너와 볼륨은 폐기했고, 새 볼륨에 마이그레이션을 다시 적용해 정상 동작을 확인했습니다.