### PR TITLE
#82/fix(setting) : 구독 재구독 즉시 결제 방지

### DIFF
--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
@@ -178,6 +178,64 @@ describe('ConfirmBillingAuthUseCase', () => {
     );
   });
 
+  it('남은 기간이 있는 해지 구독은 즉시 결제 없이 자동갱신만 재개한다', async () => {
+    const repo = createRepository();
+    const gateway = createGateway();
+    const currentPeriodEnd = new Date('2099-04-01T00:00:00.000Z');
+
+    repo.getOrCreatePersonalSubscription.mockResolvedValue(
+      createSubscription({
+        plan: SubscriptionPlan.PRO,
+        status: SubscriptionStatus.CANCELED,
+        autoRenew: false,
+        startedAt: new Date('2026-02-01T00:00:00.000Z'),
+        currentPeriodEnd,
+        nextBillingAt: null,
+        externalBillingKey: 'billing-key',
+        externalCustomerKey: 'customer-key',
+      }),
+    );
+    repo.updateSubscription.mockResolvedValue(
+      createSubscription({
+        plan: SubscriptionPlan.PRO,
+        status: SubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        startedAt: new Date('2026-02-01T00:00:00.000Z'),
+        currentPeriodEnd,
+        nextBillingAt: currentPeriodEnd,
+        externalBillingKey: 'billing-key',
+        externalCustomerKey: 'customer-key',
+      }),
+    );
+
+    const usecase = new ConfirmBillingAuthUseCase(
+      repo,
+      gateway,
+      createConfig(),
+    );
+    const result = await usecase.execute('user-id', {
+      authKey: 'auth-key',
+      customerKey: 'customer-key',
+    });
+
+    expect(gateway.issueBillingKey).not.toHaveBeenCalled();
+    expect(gateway.chargeBilling).not.toHaveBeenCalled();
+    expect(repo.activateByPayment).not.toHaveBeenCalled();
+    expect(repo.recordPaymentFailure).not.toHaveBeenCalled();
+    expect(repo.updateSubscription).toHaveBeenCalledWith('subscription-id', {
+      status: SubscriptionStatus.ACTIVE,
+      autoRenew: true,
+      nextBillingAt: currentPeriodEnd,
+    });
+    expect(result).toMatchObject({
+      plan: SubscriptionPlan.PRO,
+      status: SubscriptionStatus.ACTIVE,
+      autoRenew: true,
+      currentPeriodEnd,
+      nextBillingAt: currentPeriodEnd,
+    });
+  });
+
   it('결제 실패 시 구독을 변경하지 않고 실패 이력만 저장한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();

--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.ts
@@ -43,6 +43,19 @@ export class ConfirmBillingAuthUseCase {
       );
     }
 
+    if (this.canResumeWithoutImmediatePayment(subscription)) {
+      const updated = await this.subscriptionsRepository.updateSubscription(
+        subscription.id,
+        {
+          status: SubscriptionStatus.ACTIVE,
+          autoRenew: true,
+          nextBillingAt: subscription.currentPeriodEnd,
+        },
+      );
+
+      return toMySubscriptionResponse(updated);
+    }
+
     const amount = this.getProPlanAmount();
     const currency = this.configService.get<string>(
       'TOSS_PAYMENTS_CURRENCY',
@@ -111,6 +124,23 @@ export class ConfirmBillingAuthUseCase {
     });
 
     return toMySubscriptionResponse(updated);
+  }
+
+  private canResumeWithoutImmediatePayment(subscription: {
+    plan: SubscriptionPlan;
+    status: SubscriptionStatus;
+    currentPeriodEnd: Date | null;
+    externalBillingKey: string | null;
+    externalCustomerKey: string | null;
+  }): boolean {
+    return (
+      subscription.plan === SubscriptionPlan.PRO &&
+      subscription.status === SubscriptionStatus.CANCELED &&
+      subscription.currentPeriodEnd !== null &&
+      subscription.currentPeriodEnd > new Date() &&
+      subscription.externalBillingKey !== null &&
+      subscription.externalCustomerKey !== null
+    );
   }
 
   private getProPlanAmount(): number {


### PR DESCRIPTION
## Description

구독 취소 후 남은 이용 기간이 있는 상태에서 재구독 플로우가 들어와도 즉시 결제가 발생하지 않도록 방어 로직을 추가했습니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #82

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- `ConfirmBillingAuthUseCase`에서 결제 게이트웨이 호출 전에 남은 기간이 있는 `PRO/CANCELED` 구독을 감지합니다.
- 기존 빌링키와 customerKey가 있고 `currentPeriodEnd`가 미래인 경우 즉시 결제를 진행하지 않고 `ACTIVE`, `autoRenew=true`, `nextBillingAt=currentPeriodEnd`로 재개 처리합니다.
- 해당 케이스에서 빌링키 발급, 결제 승인, 결제 성공/실패 이력이 호출되지 않는 유스케이스 테스트를 추가했습니다.

## Performance/Scaling

- 외부 결제 게이트웨이 호출 전에 조건 분기만 추가되어 성능 영향은 제한적입니다.

## Testing done

- `pnpm test -- confirm-billing-auth.usecase.spec.ts`: 통과
- `pnpm test`: 통과 (44 suites, 134 tests)
- `pnpm lint`: 통과
- `pnpm build`: 통과

## Additional information

- 프론트엔드는 남은 기간이 있는 해지 구독에서 신규 결제 플로우 대신 `PATCH /subscriptions/me`의 `RESUME` 액션을 우선 사용해야 합니다.