### PR TITLE
#56/feat(clip) : 휴지통 자동 영구 삭제 로직 구현

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -4,3 +4,7 @@ args = ["-y", "@tosspayments/integration-guide-mcp@latest"]
 
 [mcp_servers.tosspayments-integration-guide.tools.get-v2-documents]
 approval_mode = "approve"
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@prisma/client": "^6.19.1",
     "class-transformer": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.11(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)
+      '@nestjs/schedule':
+        specifier: ^6.1.3
+        version: 6.1.3(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)
       '@nestjs/swagger':
         specifier: ^11.4.4
         version: 11.4.4(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
@@ -880,6 +883,12 @@ packages:
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
 
+  '@nestjs/schedule@6.1.3':
+    resolution: {integrity: sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@11.0.9':
     resolution: {integrity: sha512-0NfPbPlEaGwIT8/TCThxLzrlz3yzDNkfRNpbL7FiplKq3w4qXpJg0JYwqgMEJnLQZm3L/L/5XjoyfJHUO3qX9g==}
     peerDependencies:
@@ -1097,6 +1106,9 @@ packages:
 
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/luxon@3.7.2':
+    resolution: {integrity: sha512-gW+Oib+vUtGJBtNC8V9Reww0oIpusw+4m81uncg9REGZAJfqOQHfo/nkabnc7w0QReXyPqjrbWMJk6NuAkiX3Q==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -1746,6 +1758,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron@4.4.0:
+    resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
+    engines: {node: '>=18.x'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2587,6 +2603,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -4534,6 +4554,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/schedule@6.1.3(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.11)':
+    dependencies:
+      '@nestjs/common': 11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.11(@nestjs/common@11.1.11(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.11)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.4.0
+
   '@nestjs/schematics@11.0.9(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.17(chokidar@4.0.3)
@@ -4784,6 +4810,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
       '@types/node': 22.19.3
+
+  '@types/luxon@3.7.2': {}
 
   '@types/methods@1.1.4': {}
 
@@ -5468,6 +5496,11 @@ snapshots:
       typescript: 5.9.3
 
   create-require@1.1.1: {}
+
+  cron@4.4.0:
+    dependencies:
+      '@types/luxon': 3.7.2
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6510,6 +6543,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.17:
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
@@ -20,6 +21,7 @@ const envFilePath =
       envFilePath,
       isGlobal: true,
     }),
+    ScheduleModule.forRoot(),
     PrismaModule,
     AuthModule,
     UsersModule,

--- a/src/trash/application/usecases/delete-trash-clip.usecase.spec.ts
+++ b/src/trash/application/usecases/delete-trash-clip.usecase.spec.ts
@@ -11,6 +11,8 @@ const createRepository = (): jest.Mocked<TrashRepository> => ({
   findDeletedFolderById: jest.fn(),
   restoreFolderWithClips: jest.fn(),
   hardDeleteFolderWithClips: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
 });
 
 describe('DeleteTrashClipUseCase', () => {

--- a/src/trash/application/usecases/delete-trash-folder.usecase.spec.ts
+++ b/src/trash/application/usecases/delete-trash-folder.usecase.spec.ts
@@ -11,6 +11,8 @@ const createRepository = (): jest.Mocked<TrashRepository> => ({
   findDeletedFolderById: jest.fn(),
   restoreFolderWithClips: jest.fn(),
   hardDeleteFolderWithClips: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
 });
 
 describe('DeleteTrashFolderUseCase', () => {

--- a/src/trash/application/usecases/list-trash-clips.usecase.spec.ts
+++ b/src/trash/application/usecases/list-trash-clips.usecase.spec.ts
@@ -11,6 +11,8 @@ const createRepository = (): jest.Mocked<TrashRepository> => ({
   findDeletedFolderById: jest.fn(),
   restoreFolderWithClips: jest.fn(),
   hardDeleteFolderWithClips: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
 });
 
 describe('ListTrashClipsUseCase', () => {

--- a/src/trash/application/usecases/list-trash-folders.usecase.spec.ts
+++ b/src/trash/application/usecases/list-trash-folders.usecase.spec.ts
@@ -11,6 +11,8 @@ const createRepository = (): jest.Mocked<TrashRepository> => ({
   findDeletedFolderById: jest.fn(),
   restoreFolderWithClips: jest.fn(),
   hardDeleteFolderWithClips: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
 });
 
 describe('ListTrashFoldersUseCase', () => {

--- a/src/trash/application/usecases/purge-expired-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/purge-expired-trash-items.usecase.spec.ts
@@ -101,6 +101,32 @@ describe('PurgeExpiredTrashItemsUseCase', () => {
     expect(result.retentionDays).toBe(7);
   });
 
+  it('명시적으로 보관 기간 0일을 전달하면 현재 시각까지 삭제 대상으로 본다', async () => {
+    const repo = createRepository();
+    const configService = createConfigService();
+    repo.hardDeleteExpiredFoldersWithClips.mockResolvedValue(0);
+    repo.hardDeleteExpiredClips.mockResolvedValue(1);
+
+    const usecase = new PurgeExpiredTrashItemsUseCase(
+      repo,
+      configService as ConfigService,
+    );
+    const now = new Date('2026-02-01T00:00:00.000Z');
+    const result = await usecase.execute({
+      now,
+      retentionDays: 0,
+      limit: 10,
+    });
+
+    expect(repo.hardDeleteExpiredFoldersWithClips).toHaveBeenCalledWith(
+      now,
+      10,
+    );
+    expect(repo.hardDeleteExpiredClips).toHaveBeenCalledWith(now, 10);
+    expect(result.retentionDays).toBe(0);
+    expect(result.totalDeleted).toBe(1);
+  });
+
   it('환경변수가 유효하지 않으면 기본 보관 기간 30일과 기본 limit 100을 사용한다', async () => {
     const repo = createRepository();
     const configService = createConfigService({

--- a/src/trash/application/usecases/purge-expired-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/purge-expired-trash-items.usecase.spec.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ConfigService } from '@nestjs/config';
+import { TrashRepository } from '../../domain/trash.repository';
+import { PurgeExpiredTrashItemsUseCase } from './purge-expired-trash-items.usecase';
+
+const createRepository = (): jest.Mocked<TrashRepository> => ({
+  findDeletedClips: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreClip: jest.fn(),
+  hardDeleteClip: jest.fn(),
+  findDeletedFolders: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  restoreFolderWithClips: jest.fn(),
+  hardDeleteFolderWithClips: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
+});
+
+const createConfigService = (
+  values: Record<string, string | undefined> = {},
+): Pick<ConfigService, 'get'> => ({
+  get: jest.fn((key: string) => values[key]),
+});
+
+describe('PurgeExpiredTrashItemsUseCase', () => {
+  it('보관 기간이 지난 폴더를 먼저 삭제하고 남은 limit으로 클립을 삭제한다', async () => {
+    const repo = createRepository();
+    const configService = createConfigService();
+    repo.hardDeleteExpiredFoldersWithClips.mockResolvedValue(2);
+    repo.hardDeleteExpiredClips.mockResolvedValue(3);
+
+    const usecase = new PurgeExpiredTrashItemsUseCase(
+      repo,
+      configService as ConfigService,
+    );
+    const now = new Date('2026-02-01T00:00:00.000Z');
+    const result = await usecase.execute({
+      now,
+      retentionDays: 30,
+      limit: 10,
+    });
+
+    const expiresBefore = new Date('2026-01-02T00:00:00.000Z');
+    expect(repo.hardDeleteExpiredFoldersWithClips).toHaveBeenCalledWith(
+      expiresBefore,
+      10,
+    );
+    expect(repo.hardDeleteExpiredClips).toHaveBeenCalledWith(expiresBefore, 8);
+    expect(result).toEqual({
+      expiresBefore,
+      retentionDays: 30,
+      foldersDeleted: 2,
+      clipsDeleted: 3,
+      totalDeleted: 5,
+    });
+  });
+
+  it('폴더 삭제가 limit을 모두 사용하면 클립 삭제를 호출하지 않는다', async () => {
+    const repo = createRepository();
+    const configService = createConfigService();
+    repo.hardDeleteExpiredFoldersWithClips.mockResolvedValue(10);
+
+    const usecase = new PurgeExpiredTrashItemsUseCase(
+      repo,
+      configService as ConfigService,
+    );
+    const result = await usecase.execute({
+      now: new Date('2026-02-01T00:00:00.000Z'),
+      retentionDays: 30,
+      limit: 10,
+    });
+
+    expect(repo.hardDeleteExpiredClips).not.toHaveBeenCalled();
+    expect(result.clipsDeleted).toBe(0);
+    expect(result.totalDeleted).toBe(10);
+  });
+
+  it('환경변수의 보관 기간과 삭제 limit을 사용한다', async () => {
+    const repo = createRepository();
+    const configService = createConfigService({
+      TRASH_RETENTION_DAYS: '7',
+      TRASH_PURGE_LIMIT: '20',
+    });
+    repo.hardDeleteExpiredFoldersWithClips.mockResolvedValue(0);
+    repo.hardDeleteExpiredClips.mockResolvedValue(4);
+
+    const usecase = new PurgeExpiredTrashItemsUseCase(
+      repo,
+      configService as ConfigService,
+    );
+    const result = await usecase.execute({
+      now: new Date('2026-02-01T00:00:00.000Z'),
+    });
+
+    const expiresBefore = new Date('2026-01-25T00:00:00.000Z');
+    expect(repo.hardDeleteExpiredFoldersWithClips).toHaveBeenCalledWith(
+      expiresBefore,
+      20,
+    );
+    expect(repo.hardDeleteExpiredClips).toHaveBeenCalledWith(expiresBefore, 20);
+    expect(result.retentionDays).toBe(7);
+  });
+
+  it('환경변수가 유효하지 않으면 기본 보관 기간 30일과 기본 limit 100을 사용한다', async () => {
+    const repo = createRepository();
+    const configService = createConfigService({
+      TRASH_RETENTION_DAYS: 'invalid',
+      TRASH_PURGE_LIMIT: '0',
+    });
+    repo.hardDeleteExpiredFoldersWithClips.mockResolvedValue(0);
+    repo.hardDeleteExpiredClips.mockResolvedValue(0);
+
+    const usecase = new PurgeExpiredTrashItemsUseCase(
+      repo,
+      configService as ConfigService,
+    );
+    const result = await usecase.execute({
+      now: new Date('2026-02-01T00:00:00.000Z'),
+    });
+
+    const expiresBefore = new Date('2026-01-02T00:00:00.000Z');
+    expect(repo.hardDeleteExpiredFoldersWithClips).toHaveBeenCalledWith(
+      expiresBefore,
+      100,
+    );
+    expect(repo.hardDeleteExpiredClips).toHaveBeenCalledWith(
+      expiresBefore,
+      100,
+    );
+    expect(result.retentionDays).toBe(30);
+  });
+});

--- a/src/trash/application/usecases/purge-expired-trash-items.usecase.ts
+++ b/src/trash/application/usecases/purge-expired-trash-items.usecase.ts
@@ -76,7 +76,15 @@ export class PurgeExpiredTrashItemsUseCase {
     configValue: string | undefined,
     defaultValue: number,
   ): number {
-    const value = overrideValue ?? (configValue ? Number(configValue) : NaN);
+    if (
+      overrideValue !== undefined &&
+      Number.isInteger(overrideValue) &&
+      overrideValue >= 0
+    ) {
+      return overrideValue;
+    }
+
+    const value = configValue ? Number(configValue) : NaN;
 
     if (Number.isInteger(value) && value > 0) {
       return value;

--- a/src/trash/application/usecases/purge-expired-trash-items.usecase.ts
+++ b/src/trash/application/usecases/purge-expired-trash-items.usecase.ts
@@ -1,0 +1,87 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  TRASH_REPOSITORY,
+  type TrashRepository,
+} from '../../domain/trash.repository';
+
+const DEFAULT_RETENTION_DAYS = 30;
+const DEFAULT_PURGE_LIMIT = 100;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export type PurgeExpiredTrashItemsInput = {
+  now?: Date;
+  retentionDays?: number;
+  limit?: number;
+};
+
+export type PurgeExpiredTrashItemsOutput = {
+  expiresBefore: Date;
+  retentionDays: number;
+  foldersDeleted: number;
+  clipsDeleted: number;
+  totalDeleted: number;
+};
+
+@Injectable()
+export class PurgeExpiredTrashItemsUseCase {
+  constructor(
+    @Inject(TRASH_REPOSITORY)
+    private readonly trashRepository: TrashRepository,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async execute(
+    input: PurgeExpiredTrashItemsInput = {},
+  ): Promise<PurgeExpiredTrashItemsOutput> {
+    const now = input.now ?? new Date();
+    const retentionDays = this.resolvePositiveInteger(
+      input.retentionDays,
+      this.configService.get<string>('TRASH_RETENTION_DAYS'),
+      DEFAULT_RETENTION_DAYS,
+    );
+    const limit = this.resolvePositiveInteger(
+      input.limit,
+      this.configService.get<string>('TRASH_PURGE_LIMIT'),
+      DEFAULT_PURGE_LIMIT,
+    );
+    const expiresBefore = new Date(now.getTime() - retentionDays * DAY_IN_MS);
+
+    const foldersDeleted =
+      await this.trashRepository.hardDeleteExpiredFoldersWithClips(
+        expiresBefore,
+        limit,
+      );
+
+    const remainingLimit = Math.max(limit - foldersDeleted, 0);
+    const clipsDeleted =
+      remainingLimit > 0
+        ? await this.trashRepository.hardDeleteExpiredClips(
+            expiresBefore,
+            remainingLimit,
+          )
+        : 0;
+
+    return {
+      expiresBefore,
+      retentionDays,
+      foldersDeleted,
+      clipsDeleted,
+      totalDeleted: foldersDeleted + clipsDeleted,
+    };
+  }
+
+  private resolvePositiveInteger(
+    overrideValue: number | undefined,
+    configValue: string | undefined,
+    defaultValue: number,
+  ): number {
+    const value = overrideValue ?? (configValue ? Number(configValue) : NaN);
+
+    if (Number.isInteger(value) && value > 0) {
+      return value;
+    }
+
+    return defaultValue;
+  }
+}

--- a/src/trash/application/usecases/restore-trash-clip.usecase.spec.ts
+++ b/src/trash/application/usecases/restore-trash-clip.usecase.spec.ts
@@ -11,6 +11,8 @@ const createRepository = (): jest.Mocked<TrashRepository> => ({
   findDeletedFolderById: jest.fn(),
   restoreFolderWithClips: jest.fn(),
   hardDeleteFolderWithClips: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
 });
 
 describe('RestoreTrashClipUseCase', () => {

--- a/src/trash/application/usecases/restore-trash-folder.usecase.spec.ts
+++ b/src/trash/application/usecases/restore-trash-folder.usecase.spec.ts
@@ -11,6 +11,8 @@ const createRepository = (): jest.Mocked<TrashRepository> => ({
   findDeletedFolderById: jest.fn(),
   restoreFolderWithClips: jest.fn(),
   hardDeleteFolderWithClips: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
 });
 
 describe('RestoreTrashFolderUseCase', () => {

--- a/src/trash/domain/trash.repository.ts
+++ b/src/trash/domain/trash.repository.ts
@@ -17,4 +17,9 @@ export interface TrashRepository {
   ): Promise<TrashFolderItem | null>;
   restoreFolderWithClips(folderId: string): Promise<TrashFolderItem>;
   hardDeleteFolderWithClips(folderId: string): Promise<void>;
+  hardDeleteExpiredFoldersWithClips(
+    expiresBefore: Date,
+    limit: number,
+  ): Promise<number>;
+  hardDeleteExpiredClips(expiresBefore: Date, limit: number): Promise<number>;
 }

--- a/src/trash/infrastructure/prisma-trash.repository.ts
+++ b/src/trash/infrastructure/prisma-trash.repository.ts
@@ -158,4 +158,80 @@ export class PrismaTrashRepository implements TrashRepository {
       });
     });
   }
+
+  async hardDeleteExpiredFoldersWithClips(
+    expiresBefore: Date,
+    limit: number,
+  ): Promise<number> {
+    const folders = await this.prisma.folder.findMany({
+      where: {
+        deletedAt: {
+          lte: expiresBefore,
+        },
+      },
+      orderBy: [{ deletedAt: 'asc' }, { id: 'asc' }],
+      take: limit,
+      select: {
+        id: true,
+      },
+    });
+
+    if (folders.length === 0) {
+      return 0;
+    }
+
+    const result = await this.prisma.folder.deleteMany({
+      where: {
+        id: {
+          in: folders.map((folder) => folder.id),
+        },
+        deletedAt: {
+          lte: expiresBefore,
+        },
+      },
+    });
+
+    return result.count;
+  }
+
+  async hardDeleteExpiredClips(
+    expiresBefore: Date,
+    limit: number,
+  ): Promise<number> {
+    const clips = await this.prisma.clip.findMany({
+      where: {
+        deletedAt: {
+          lte: expiresBefore,
+        },
+        folder: {
+          deletedAt: null,
+        },
+      },
+      orderBy: [{ deletedAt: 'asc' }, { id: 'asc' }],
+      take: limit,
+      select: {
+        id: true,
+      },
+    });
+
+    if (clips.length === 0) {
+      return 0;
+    }
+
+    const result = await this.prisma.clip.deleteMany({
+      where: {
+        id: {
+          in: clips.map((clip) => clip.id),
+        },
+        deletedAt: {
+          lte: expiresBefore,
+        },
+        folder: {
+          deletedAt: null,
+        },
+      },
+    });
+
+    return result.count;
+  }
 }

--- a/src/trash/infrastructure/trash-cleanup.scheduler.ts
+++ b/src/trash/infrastructure/trash-cleanup.scheduler.ts
@@ -10,7 +10,7 @@ export class TrashCleanupScheduler {
     private readonly purgeExpiredTrashItemsUseCase: PurgeExpiredTrashItemsUseCase,
   ) {}
 
-  @Cron('0 3 * * *', {
+  @Cron('* * * * *', {
     name: 'trash-cleanup',
     timeZone: 'Asia/Seoul',
     waitForCompletion: true,

--- a/src/trash/infrastructure/trash-cleanup.scheduler.ts
+++ b/src/trash/infrastructure/trash-cleanup.scheduler.ts
@@ -10,16 +10,14 @@ export class TrashCleanupScheduler {
     private readonly purgeExpiredTrashItemsUseCase: PurgeExpiredTrashItemsUseCase,
   ) {}
 
-  @Cron('* * * * *', {
+  @Cron('0 3 * * *', {
     name: 'trash-cleanup',
     timeZone: 'Asia/Seoul',
     waitForCompletion: true,
   })
   async handleTrashCleanup() {
     try {
-      const result = await this.purgeExpiredTrashItemsUseCase.execute({
-        retentionDays: 0,
-      });
+      const result = await this.purgeExpiredTrashItemsUseCase.execute();
 
       this.logger.log(
         `휴지통 자동 정리 완료: folders=${result.foldersDeleted}, clips=${result.clipsDeleted}, expiresBefore=${result.expiresBefore.toISOString()}`,

--- a/src/trash/infrastructure/trash-cleanup.scheduler.ts
+++ b/src/trash/infrastructure/trash-cleanup.scheduler.ts
@@ -17,7 +17,9 @@ export class TrashCleanupScheduler {
   })
   async handleTrashCleanup() {
     try {
-      const result = await this.purgeExpiredTrashItemsUseCase.execute();
+      const result = await this.purgeExpiredTrashItemsUseCase.execute({
+        retentionDays: 0,
+      });
 
       this.logger.log(
         `휴지통 자동 정리 완료: folders=${result.foldersDeleted}, clips=${result.clipsDeleted}, expiresBefore=${result.expiresBefore.toISOString()}`,

--- a/src/trash/infrastructure/trash-cleanup.scheduler.ts
+++ b/src/trash/infrastructure/trash-cleanup.scheduler.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PurgeExpiredTrashItemsUseCase } from '../application/usecases/purge-expired-trash-items.usecase';
+
+@Injectable()
+export class TrashCleanupScheduler {
+  private readonly logger = new Logger(TrashCleanupScheduler.name);
+
+  constructor(
+    private readonly purgeExpiredTrashItemsUseCase: PurgeExpiredTrashItemsUseCase,
+  ) {}
+
+  @Cron('0 3 * * *', {
+    name: 'trash-cleanup',
+    timeZone: 'Asia/Seoul',
+    waitForCompletion: true,
+  })
+  async handleTrashCleanup() {
+    try {
+      const result = await this.purgeExpiredTrashItemsUseCase.execute();
+
+      this.logger.log(
+        `휴지통 자동 정리 완료: folders=${result.foldersDeleted}, clips=${result.clipsDeleted}, expiresBefore=${result.expiresBefore.toISOString()}`,
+      );
+    } catch (error) {
+      this.logger.error('휴지통 자동 정리 중 오류가 발생했습니다.', error);
+    }
+  }
+}

--- a/src/trash/trash.module.ts
+++ b/src/trash/trash.module.ts
@@ -9,6 +9,8 @@ import { DeleteTrashClipUseCase } from './application/usecases/delete-trash-clip
 import { ListTrashFoldersUseCase } from './application/usecases/list-trash-folders.usecase';
 import { RestoreTrashFolderUseCase } from './application/usecases/restore-trash-folder.usecase';
 import { DeleteTrashFolderUseCase } from './application/usecases/delete-trash-folder.usecase';
+import { PurgeExpiredTrashItemsUseCase } from './application/usecases/purge-expired-trash-items.usecase';
+import { TrashCleanupScheduler } from './infrastructure/trash-cleanup.scheduler';
 
 @Module({
   controllers: [TrashController],
@@ -20,6 +22,8 @@ import { DeleteTrashFolderUseCase } from './application/usecases/delete-trash-fo
     ListTrashFoldersUseCase,
     RestoreTrashFolderUseCase,
     DeleteTrashFolderUseCase,
+    PurgeExpiredTrashItemsUseCase,
+    TrashCleanupScheduler,
     JwtAccessGuard,
   ],
 })

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -23,6 +23,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   it('/ (GET)', () => {
     const instance = app.getHttpAdapter().getInstance() as unknown as App;
 


### PR DESCRIPTION
## Description

휴지통으로 이동된 클립/폴더를 보관 기간 이후 자동으로 영구 삭제하는 로직을 추가했습니다.

기본 보관 기간은 30일이며, `TRASH_RETENTION_DAYS` 환경변수로 조정할 수 있습니다. 자동 정리는 `@nestjs/schedule` 기반으로 매일 03:00 Asia/Seoul에 실행됩니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)

## Linked tickets and other PRs

- Closes #56

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `PurgeExpiredTrashItemsUseCase`를 추가해 만료 기준 계산, 폴더 우선 삭제, 남은 limit 기반 클립 삭제를 처리했습니다.
- `TrashRepository`에 만료된 폴더/클립 영구 삭제 포트를 추가하고 Prisma 구현체에 반영했습니다.
- `TrashCleanupScheduler`를 추가해 매일 03:00에 휴지통 자동 정리 유스케이스를 호출합니다.
- `ScheduleModule.forRoot()`와 `@nestjs/schedule` 의존성을 추가했습니다.
- e2e 테스트 앱 종료 시 열린 핸들이 남지 않도록 `app.close()`를 추가했습니다.
- 요청에 따라 `.codex/config.toml` 변경도 포함했습니다.

## Performance/Scaling

- 삭제 대상은 `limit` 기반으로 처리해 한 번의 스케줄 실행에서 과도한 삭제 작업이 몰리지 않도록 했습니다.
- 폴더를 먼저 삭제하고, 이후 활성 폴더에 속한 만료 클립만 삭제해 폴더 하위 클립의 중복 삭제를 줄였습니다.
- 삭제 조건에 `deletedAt`을 다시 포함해 스케줄 중복 실행이나 복구 경쟁 상황에서도 활성 항목을 삭제하지 않도록 했습니다.

## Testing done

- `pnpm lint` 통과
- `pnpm test` 통과, 45 suites / 138 tests
- `pnpm build` 통과
- `pnpm test:e2e` 통과, 1 test
- 테스트용으로 1분 주기 및 즉시 삭제 기준을 적용해 수동 동작 확인 후, 운영 기준인 30일 보관/매일 03:00 실행으로 복구했습니다.

## Additional information

- `gh auth status` 기준 로컬 GitHub CLI 토큰은 만료되어 있었지만, SSH 기반 `git push`와 GitHub 앱 커넥터로 PR 생성은 완료했습니다.