### PR TITLE
#92/fix(setting) : 자동갱신 중복 과금 방지

### DIFF
--- a/prisma/migrations/20260626000000_add_subscription_payment_pending_status/migration.sql
+++ b/prisma/migrations/20260626000000_add_subscription_payment_pending_status/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "SubscriptionPaymentStatus" ADD VALUE 'PENDING';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ enum PaymentProvider {
 }
 
 enum SubscriptionPaymentStatus {
+  PENDING
   DONE
   FAILED
   CANCELED

--- a/src/subscriptions/application/helpers/customer-key.helper.ts
+++ b/src/subscriptions/application/helpers/customer-key.helper.ts
@@ -7,3 +7,15 @@ export function createExternalCustomerKey(userId: string): string {
 export function createSubscriptionOrderId(subscriptionId: string): string {
   return `sub_${subscriptionId}_${Date.now()}_${randomUUID()}`;
 }
+
+export function createAutoRenewalSubscriptionOrderId(
+  subscriptionId: string,
+  nextBillingAt: Date,
+): string {
+  const billingPeriodKey = nextBillingAt
+    .toISOString()
+    .replace(/\D/g, '')
+    .slice(0, 14);
+
+  return `sub_${subscriptionId}_${billingPeriodKey}`;
+}

--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
@@ -33,6 +33,7 @@ const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
   updateSubscription: jest.fn(),
   activateByPayment: jest.fn(),
   recordPaymentFailure: jest.fn(),
+  claimAutoRenewalPayment: jest.fn(),
   findDueAutoRenewalSubscriptions: jest.fn(),
 });
 

--- a/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
@@ -16,6 +16,7 @@ const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
   updateSubscription: jest.fn(),
   activateByPayment: jest.fn(),
   recordPaymentFailure: jest.fn(),
+  claimAutoRenewalPayment: jest.fn(),
   findDueAutoRenewalSubscriptions: jest.fn(),
 });
 
@@ -137,9 +138,10 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
     repo.findDueAutoRenewalSubscriptions.mockResolvedValue([
       createSubscription(),
     ]);
+    repo.claimAutoRenewalPayment.mockResolvedValue(true);
     gateway.chargeBilling.mockResolvedValue({
       paymentKey: 'payment-key',
-      orderId: 'order-id',
+      orderId: 'provider-order-id',
       status: SubscriptionPaymentStatus.DONE,
       totalAmount: 4900,
       currency: 'KRW',
@@ -156,8 +158,21 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
     );
     const result = await usecase.execute(createInput(now));
 
+    expect(repo.claimAutoRenewalPayment).toHaveBeenCalledWith({
+      subscriptionId: 'subscription-id',
+      provider: PaymentProvider.TOSS_PAYMENTS,
+      externalOrderId: 'sub_subscription-id_20260201000000',
+      amount: 4900,
+      currency: 'KRW',
+    });
+    expect(gateway.chargeBilling).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderId: 'sub_subscription-id_20260201000000',
+      }),
+    );
     expect(repo.activateByPayment).toHaveBeenCalledWith(
       expect.objectContaining({
+        externalOrderId: 'sub_subscription-id_20260201000000',
         currentPeriodEnd: new Date('2026-03-01T00:00:00.000Z'),
         nextBillingAt: new Date('2026-03-01T00:00:00.000Z'),
       }),
@@ -177,9 +192,10 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
     repo.findDueAutoRenewalSubscriptions.mockResolvedValue([
       createSubscription(),
     ]);
+    repo.claimAutoRenewalPayment.mockResolvedValue(true);
     gateway.chargeBilling.mockResolvedValue({
       paymentKey: 'payment-key',
-      orderId: 'order-id',
+      orderId: 'provider-order-id',
       status: SubscriptionPaymentStatus.FAILED,
       totalAmount: 4900,
       currency: 'KRW',
@@ -198,6 +214,7 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
 
     expect(repo.recordPaymentFailure).toHaveBeenCalledWith(
       expect.objectContaining({
+        externalOrderId: 'sub_subscription-id_20260201000000',
         status: SubscriptionPaymentStatus.FAILED,
         failureCode: 'PAY_PROCESS_ABORTED',
       }),
@@ -207,6 +224,40 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
       processed: 1,
       succeeded: 0,
       failed: 1,
+    });
+  });
+
+  it('동일 청구주기 결제가 이미 claim되어 있으면 외부 과금을 건너뛴다', async () => {
+    const repo = createRepository();
+    const gateway = createGateway();
+    const now = new Date('2026-02-01T00:00:00.000Z');
+
+    repo.findDueAutoRenewalSubscriptions.mockResolvedValue([
+      createSubscription(),
+    ]);
+    repo.claimAutoRenewalPayment.mockResolvedValue(false);
+
+    const usecase = new ProcessDueAutoRenewalsUseCase(
+      repo,
+      gateway,
+      createConfig(),
+    );
+    const result = await usecase.execute(createInput(now));
+
+    expect(repo.claimAutoRenewalPayment).toHaveBeenCalledWith({
+      subscriptionId: 'subscription-id',
+      provider: PaymentProvider.TOSS_PAYMENTS,
+      externalOrderId: 'sub_subscription-id_20260201000000',
+      amount: 4900,
+      currency: 'KRW',
+    });
+    expect(gateway.chargeBilling).not.toHaveBeenCalled();
+    expect(repo.activateByPayment).not.toHaveBeenCalled();
+    expect(repo.recordPaymentFailure).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      processed: 1,
+      succeeded: 0,
+      failed: 0,
     });
   });
 });

--- a/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.ts
+++ b/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.ts
@@ -9,7 +9,7 @@ import {
 } from '../../domain/subscription.types';
 import { BILLING_PAYMENT_GATEWAY } from '../ports/billing-payment.gateway';
 import type { BillingPaymentGateway } from '../ports/billing-payment.gateway';
-import { createSubscriptionOrderId } from '../helpers/customer-key.helper';
+import { createAutoRenewalSubscriptionOrderId } from '../helpers/customer-key.helper';
 import { resolveNextPeriod } from '../helpers/subscription-period.helper';
 import { SubscriptionsError } from '../errors/subscriptions.error';
 
@@ -71,7 +71,23 @@ export class ProcessDueAutoRenewalsUseCase {
         'TOSS_PAYMENTS_CURRENCY',
         'KRW',
       );
-      const orderId = createSubscriptionOrderId(subscription.id);
+      const orderId = createAutoRenewalSubscriptionOrderId(
+        subscription.id,
+        subscription.nextBillingAt ?? now,
+      );
+
+      const claimed =
+        await this.subscriptionsRepository.claimAutoRenewalPayment({
+          subscriptionId: subscription.id,
+          provider: PaymentProvider.TOSS_PAYMENTS,
+          externalOrderId: orderId,
+          amount,
+          currency,
+        });
+
+      if (!claimed) {
+        continue;
+      }
 
       const paymentResult = await this.billingPaymentGateway.chargeBilling({
         billingKey: subscription.externalBillingKey,
@@ -96,7 +112,7 @@ export class ProcessDueAutoRenewalsUseCase {
           externalBillingKey: subscription.externalBillingKey,
           externalCustomerKey: subscription.externalCustomerKey,
           externalPaymentKey: paymentResult.paymentKey,
-          externalOrderId: paymentResult.orderId,
+          externalOrderId: orderId,
           amount: paymentResult.totalAmount,
           currency: paymentResult.currency,
           approvedAt: paidAt,
@@ -114,7 +130,7 @@ export class ProcessDueAutoRenewalsUseCase {
         provider: PaymentProvider.TOSS_PAYMENTS,
         status: SubscriptionPaymentStatus.FAILED,
         externalPaymentKey: paymentResult.paymentKey,
-        externalOrderId: paymentResult.orderId,
+        externalOrderId: orderId,
         amount,
         currency,
         failedAt: now,

--- a/src/subscriptions/application/usecases/update-my-subscription.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/update-my-subscription.usecase.spec.ts
@@ -14,6 +14,7 @@ const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
   updateSubscription: jest.fn(),
   activateByPayment: jest.fn(),
   recordPaymentFailure: jest.fn(),
+  claimAutoRenewalPayment: jest.fn(),
   findDueAutoRenewalSubscriptions: jest.fn(),
 });
 

--- a/src/subscriptions/domain/subscription.types.ts
+++ b/src/subscriptions/domain/subscription.types.ts
@@ -23,6 +23,7 @@ export type PaymentProvider =
   (typeof PaymentProvider)[keyof typeof PaymentProvider];
 
 export const SubscriptionPaymentStatus = {
+  PENDING: 'PENDING',
   DONE: 'DONE',
   FAILED: 'FAILED',
   CANCELED: 'CANCELED',

--- a/src/subscriptions/domain/subscriptions.repository.ts
+++ b/src/subscriptions/domain/subscriptions.repository.ts
@@ -46,6 +46,14 @@ export type ActivateSubscriptionPaymentParams =
 
 export type MarkPaymentFailedParams = RecordSubscriptionPaymentParams;
 
+export type ClaimAutoRenewalPaymentParams = {
+  subscriptionId: string;
+  provider: PaymentProvider;
+  externalOrderId: string;
+  amount: number;
+  currency: string;
+};
+
 export interface SubscriptionsRepository {
   getOrCreatePersonalSubscription(userId: string): Promise<Subscription>;
 
@@ -59,6 +67,10 @@ export interface SubscriptionsRepository {
   ): Promise<Subscription>;
 
   recordPaymentFailure(params: MarkPaymentFailedParams): Promise<void>;
+
+  claimAutoRenewalPayment(
+    params: ClaimAutoRenewalPaymentParams,
+  ): Promise<boolean>;
 
   findDueAutoRenewalSubscriptions(
     now: Date,

--- a/src/subscriptions/infrastructure/prisma-subscriptions.repository.ts
+++ b/src/subscriptions/infrastructure/prisma-subscriptions.repository.ts
@@ -9,11 +9,15 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
   ActivateSubscriptionPaymentParams,
+  ClaimAutoRenewalPaymentParams,
   MarkPaymentFailedParams,
   SubscriptionsRepository,
   UpdateSubscriptionParams,
 } from '../domain/subscriptions.repository';
-import { Subscription } from '../domain/subscription.types';
+import {
+  Subscription,
+  SubscriptionPaymentStatus,
+} from '../domain/subscription.types';
 
 const subscriptionSelect = {
   id: true,
@@ -88,7 +92,7 @@ export class PrismaSubscriptionsRepository implements SubscriptionsRepository {
         where: {
           externalOrderId: params.externalOrderId,
         },
-        update: {},
+        update: this.toPaymentUpdateData(params),
         create: this.toPaymentCreateData(params),
       });
 
@@ -117,9 +121,42 @@ export class PrismaSubscriptionsRepository implements SubscriptionsRepository {
       where: {
         externalOrderId: params.externalOrderId,
       },
-      update: {},
+      update: this.toPaymentUpdateData(params),
       create: this.toPaymentCreateData(params),
     });
+  }
+
+  async claimAutoRenewalPayment(
+    params: ClaimAutoRenewalPaymentParams,
+  ): Promise<boolean> {
+    try {
+      await this.prisma.subscriptionPayment.create({
+        data: {
+          provider: params.provider as PrismaPaymentProvider,
+          status:
+            SubscriptionPaymentStatus.PENDING as PrismaSubscriptionPaymentStatus,
+          externalOrderId: params.externalOrderId,
+          amount: params.amount,
+          currency: params.currency,
+          subscription: {
+            connect: {
+              id: params.subscriptionId,
+            },
+          },
+        },
+      });
+
+      return true;
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return false;
+      }
+
+      throw error;
+    }
   }
 
   async findDueAutoRenewalSubscriptions(
@@ -182,6 +219,31 @@ export class PrismaSubscriptionsRepository implements SubscriptionsRepository {
       status: params.status as PrismaSubscriptionPaymentStatus,
       externalPaymentKey: params.externalPaymentKey ?? null,
       externalOrderId: params.externalOrderId,
+      externalEventId: params.externalEventId ?? null,
+      amount: params.amount,
+      currency: params.currency,
+      approvedAt: params.approvedAt ?? null,
+      failedAt: params.failedAt ?? null,
+      failureCode: params.failureCode ?? null,
+      failureMessage: params.failureMessage ?? null,
+      ...(params.rawData !== undefined
+        ? { rawData: params.rawData as Prisma.InputJsonValue }
+        : {}),
+      subscription: {
+        connect: {
+          id: params.subscriptionId,
+        },
+      },
+    };
+  }
+
+  private toPaymentUpdateData(
+    params: MarkPaymentFailedParams,
+  ): Prisma.SubscriptionPaymentUpdateInput {
+    return {
+      provider: params.provider as PrismaPaymentProvider,
+      status: params.status as PrismaSubscriptionPaymentStatus,
+      externalPaymentKey: params.externalPaymentKey ?? null,
       externalEventId: params.externalEventId ?? null,
       amount: params.amount,
       currency: params.currency,


### PR DESCRIPTION
## Description

자동갱신 배치가 동시에 실행될 때 같은 구독/청구주기에 대해 외부 과금이 중복 호출될 수 있던 문제를 막았습니다. 청구주기 기반 deterministic orderId와 PENDING 결제 row claim을 추가해, 이미 처리 중인 결제는 외부 gateway 호출 전에 건너뜁니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)

## Linked tickets and other PRs

- Closes #92, refs #84
- Requires #101
- Ports 없음

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `SubscriptionPaymentStatus.PENDING`을 추가하고 migration을 포함했습니다.
- 자동갱신 배치 orderId를 `subscriptionId + nextBillingAt` 기반으로 결정적으로 생성합니다.
- 외부 과금 전 `SubscriptionPayment` PENDING row를 먼저 생성해 청구주기를 claim합니다.
- unique 충돌이 발생하면 이미 처리 중/처리 완료된 청구주기로 보고 외부 과금을 호출하지 않습니다.
- 과금 성공/실패 결과는 claim에 사용한 deterministic orderId의 payment row를 갱신합니다.
- 최초 빌링 인증 결제는 기존 랜덤 orderId 흐름을 유지합니다.

## Performance/Scaling

자동갱신 대상 구독마다 결제 전 insert claim이 1회 추가됩니다. 대신 중복 배치 실행 시 외부 결제 gateway 중복 호출을 DB unique 제약으로 차단합니다.

## Testing done

- `pnpm test -- process-due-auto-renewals.usecase.spec.ts confirm-billing-auth.usecase.spec.ts update-my-subscription.usecase.spec.ts`
- `pnpm prisma validate`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Additional information

- base branch: `fix/87`
- 선행 PR: #101
- 권장 병합 순서: #101을 먼저 `dev`에 병합한 뒤, 이 PR의 base를 `dev`로 변경하거나 rebase 후 병합합니다.
- DB migration 포함: `20260626000000_add_subscription_payment_pending_status`


## 리뷰용 요약

### 문제 정의
자동갱신 배치가 동시에 실행되면 같은 구독 주기에 대해 결제가 중복으로 생성/청구될 수 있었습니다.

### 해결 방법 구성
구독 주기 단위로 먼저 결제 처리권을 claim하고, 동일 주기에 대해 하나의 pending payment만 생성되도록 멱등성을 구성했습니다.

### 해결
`PENDING` 결제 상태와 migration을 추가하고, 구독 ID와 다음 결제일 기반의 결정적 `orderId`, repository claim 로직을 도입했습니다.

### 결과
동시 실행이나 반복 실행 상황에서도 같은 구독/결제 주기에 대한 중복 과금 위험이 줄어듭니다.