### PR TITLE
#95/fix(user) : 회원 탈퇴 전 리프레시 토큰 삭제

### DIFF
--- a/src/users/infrastructure/prisma-users.repository.spec.ts
+++ b/src/users/infrastructure/prisma-users.repository.spec.ts
@@ -1,0 +1,46 @@
+import { PrismaUsersRepository } from './prisma-users.repository';
+
+describe('PrismaUsersRepository', () => {
+  it('회원 탈퇴 시 refresh token을 먼저 삭제한 뒤 사용자 row를 삭제한다', async () => {
+    const tx = {
+      refreshToken: {
+        deleteMany: jest.fn().mockResolvedValue(undefined),
+      },
+      workspace: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'workspace-id' }]),
+        deleteMany: jest.fn().mockResolvedValue(undefined),
+      },
+      user: {
+        delete: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+    const prisma = {
+      $transaction: jest.fn((callback: (args: typeof tx) => unknown) =>
+        Promise.resolve(callback(tx)),
+      ),
+    } as never;
+
+    const repository = new PrismaUsersRepository(prisma);
+
+    await repository.deleteUserAndOwnedPersonalWorkspaces('user-id');
+
+    expect(tx.refreshToken.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-id',
+      },
+    });
+    expect(tx.workspace.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: ['workspace-id'],
+        },
+      },
+    });
+    expect(tx.user.delete).toHaveBeenCalledWith({
+      where: { id: 'user-id' },
+    });
+    expect(tx.refreshToken.deleteMany.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.user.delete.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/src/users/infrastructure/prisma-users.repository.ts
+++ b/src/users/infrastructure/prisma-users.repository.ts
@@ -91,6 +91,12 @@ export class PrismaUsersRepository implements UsersRepository {
 
   async deleteUserAndOwnedPersonalWorkspaces(userId: string): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
+      await tx.refreshToken.deleteMany({
+        where: {
+          userId,
+        },
+      });
+
       const ownedPersonalWorkspaces = await tx.workspace.findMany({
         where: {
           ownerUserId: userId,


### PR DESCRIPTION
## Description

로그인 이력이 있는 사용자가 회원 탈퇴할 때 `RefreshToken` FK 제약 때문에 `User` 삭제가 실패할 수 있는 문제를 수정했습니다. 탈퇴 transaction 안에서 해당 사용자의 refresh token을 먼저 삭제한 뒤 워크스페이스와 사용자 row를 삭제합니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #95, refs #84
- Requires 없음
- Ports 없음

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `PrismaUsersRepository.deleteUserAndOwnedPersonalWorkspaces()` transaction 시작 시 `refreshToken.deleteMany({ userId })`를 먼저 실행합니다.
- 기존 FK 제약과 schema는 변경하지 않고, 삭제 순서로 제약 실패를 방지합니다.
- repository 테스트를 추가해 refresh token 삭제가 user 삭제보다 먼저 호출되는지 검증했습니다.

## Performance/Scaling

회원 탈퇴 시 사용자별 refresh token 삭제 쿼리 1회가 추가됩니다. 일반 요청 경로에는 영향이 없습니다.

## Testing done

- `pnpm test -- delete-me.usecase.spec.ts prisma-users.repository.spec.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Additional information

- base branch: `dev`


## 리뷰용 요약

### 문제 정의
회원 탈퇴 시 refresh token row가 남아 있으면 FK 제약 때문에 사용자 삭제가 실패할 수 있었습니다.

### 해결 방법 구성
회원 삭제 transaction 안에서 refresh token을 먼저 삭제한 뒤 사용자/워크스페이스 삭제가 진행되도록 순서를 정리했습니다.

### 해결
`PrismaUsersRepository`의 탈퇴 transaction에서 `refreshToken.deleteMany({ userId })`를 먼저 실행하도록 변경하고, 삭제 순서 테스트를 추가했습니다.

### 결과
로그인 이력이 있는 사용자도 FK 제약에 막히지 않고 정상 탈퇴할 수 있습니다.