### PR TITLE
#88/fix(clip) : 삭제 폴더 클립 단독 복구 차단

### DIFF
--- a/src/clips/infrastructure/prisma-clips.repository.ts
+++ b/src/clips/infrastructure/prisma-clips.repository.ts
@@ -404,10 +404,16 @@ export class PrismaClipsRepository implements ClipsRepository {
         ? {
             folderId,
             ...(workspaceId ? { workspaceId } : {}),
+            folder: {
+              deletedAt: null,
+            },
           }
         : {
             workspace: {
               ownerUserId: userId,
+            },
+            folder: {
+              deletedAt: null,
             },
           }),
       ...(type ? { type } : {}),

--- a/src/trash/application/usecases/restore-trash-clip.usecase.spec.ts
+++ b/src/trash/application/usecases/restore-trash-clip.usecase.spec.ts
@@ -47,4 +47,23 @@ describe('RestoreTrashClipUseCase', () => {
 
     expect(repo.restoreClip).toHaveBeenCalledWith('clip-1');
   });
+
+  it('부모 폴더가 삭제된 클립은 단독 복구를 거부한다', async () => {
+    const repo = createRepository();
+    repo.findDeletedClipById.mockResolvedValue({
+      id: 'clip-1',
+      title: '삭제된 클립',
+      type: 'TEXT',
+      folderId: 'folder-1',
+      deletedAt: new Date(),
+      folderDeletedAt: new Date(),
+    });
+
+    const usecase = new RestoreTrashClipUseCase(repo);
+
+    await expect(usecase.execute('user-1', 'clip-1')).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    expect(repo.restoreClip).not.toHaveBeenCalled();
+  });
 });

--- a/src/trash/application/usecases/restore-trash-clip.usecase.ts
+++ b/src/trash/application/usecases/restore-trash-clip.usecase.ts
@@ -19,6 +19,13 @@ export class RestoreTrashClipUseCase {
       throw new TrashError('NOT_FOUND', '휴지통 클립을 찾을 수 없습니다.');
     }
 
+    if (clip.folderDeletedAt) {
+      throw new TrashError(
+        'CONFLICT',
+        '삭제된 폴더에 속한 클립은 단독으로 복구할 수 없습니다.',
+      );
+    }
+
     return this.trashRepository.restoreClip(clip.id);
   }
 }

--- a/src/trash/domain/trash.types.ts
+++ b/src/trash/domain/trash.types.ts
@@ -10,4 +10,5 @@ export type TrashClipItem = {
   type: 'TEXT' | 'COLOR' | 'IMAGE';
   folderId: string;
   deletedAt: Date | null;
+  folderDeletedAt?: Date | null;
 };

--- a/src/trash/infrastructure/prisma-trash.repository.ts
+++ b/src/trash/infrastructure/prisma-trash.repository.ts
@@ -32,7 +32,7 @@ export class PrismaTrashRepository implements TrashRepository {
     userId: string,
     clipId: string,
   ): Promise<TrashClipItem | null> {
-    return this.prisma.clip.findFirst({
+    const clip = await this.prisma.clip.findFirst({
       where: {
         id: clipId,
         deletedAt: {
@@ -48,8 +48,26 @@ export class PrismaTrashRepository implements TrashRepository {
         type: true,
         folderId: true,
         deletedAt: true,
+        folder: {
+          select: {
+            deletedAt: true,
+          },
+        },
       },
-    }) as Promise<TrashClipItem | null>;
+    });
+
+    if (!clip) {
+      return null;
+    }
+
+    return {
+      id: clip.id,
+      title: clip.title,
+      type: clip.type,
+      folderId: clip.folderId,
+      deletedAt: clip.deletedAt,
+      folderDeletedAt: clip.folder.deletedAt,
+    } as TrashClipItem;
   }
 
   async restoreClip(clipId: string): Promise<TrashClipItem> {

--- a/src/trash/presentation/trash.controller.ts
+++ b/src/trash/presentation/trash.controller.ts
@@ -9,6 +9,7 @@ import {
   UseFilters,
 } from '@nestjs/common';
 import {
+  ApiConflictResponse,
   ApiBearerAuth,
   ApiNotFoundResponse,
   ApiOkResponse,
@@ -74,6 +75,10 @@ export class TrashController {
   })
   @ApiNotFoundResponse({
     description: '휴지통 클립을 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
+  @ApiConflictResponse({
+    description: '삭제된 폴더에 속한 클립은 단독으로 복구할 수 없습니다.',
     type: ErrorResponseDto,
   })
   restoreTrashClip(


### PR DESCRIPTION
## Description

삭제된 폴더 안의 클립을 휴지통에서 단독 복구할 수 있어 활성 클립과 삭제 폴더가 함께 존재하는 불일치 상태가 생기던 문제를 수정했습니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #88, refs #84
- Requires 없음
- Ports 없음

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- 휴지통 클립 단건 조회 시 부모 폴더의 `deletedAt`을 함께 조회합니다.
- 부모 폴더가 삭제된 상태면 클립 단독 복구를 `CONFLICT`로 거부합니다.
- 활성 클립 목록 공통 Prisma where에 `folder.deletedAt = null` 조건을 추가해 삭제 폴더의 클립 노출을 막습니다.
- 휴지통 클립 복구 API에 409 응답 문서를 추가했습니다.

## Performance/Scaling

활성 클립 목록에 folder relation 조건이 추가됩니다. 기존 folder/workspace 인덱스를 활용하는 조회 흐름이며, 삭제 폴더 클립 노출을 막기 위한 정합성 조건입니다.

## Testing done

- `pnpm test -- restore-trash-clip.usecase.spec.ts list-recent-clips.usecase.spec.ts list-favorite-clips.usecase.spec.ts list-folder-clips.usecase.spec.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Additional information

- base branch: `dev`
- 후속 스택 브랜치: `refactor/89`는 이 PR의 브랜치(`fix/88`)를 base로 분기할 예정입니다.
- 권장 병합 순서: #88 병합 후 #89 PR을 `dev` 기준으로 rebase/base 변경한 뒤 병합합니다.


## 리뷰용 요약

### 문제 정의
삭제된 폴더 안의 클립을 단독 복구하면 부모 폴더는 삭제 상태인데 클립만 활성화되는 데이터 불일치가 발생할 수 있었습니다.

### 해결 방법 구성
부모 폴더가 삭제된 상태에서는 클립 단독 복구를 막고, 활성 클립 목록에서도 삭제된 폴더의 클립이 노출되지 않도록 구성했습니다.

### 해결
휴지통 클립 조회에 부모 폴더 삭제 상태를 포함하고, 복구 usecase에서 삭제된 부모 폴더를 가진 클립은 `CONFLICT`로 거부했습니다. 활성 목록 query도 폴더 삭제 상태를 확인하도록 보강했습니다.

### 결과
soft delete 상태가 꼬이는 것을 막고, 삭제된 폴더 하위 클립이 활성 목록에 잘못 노출되지 않습니다.