### PR TITLE
#94/fix(clip) : SVG 이미지 업로드 차단

### DIFF
--- a/src/clips/application/helpers/clip-data.helper.ts
+++ b/src/clips/application/helpers/clip-data.helper.ts
@@ -11,6 +11,18 @@ export type ClipData = {
   imageUrl: string | null;
 };
 
+export const ALLOWED_CLIP_IMAGE_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/avif',
+] as const;
+
+export function isAllowedClipImageMimeType(mimetype: string): boolean {
+  return ALLOWED_CLIP_IMAGE_MIME_TYPES.some((allowed) => allowed === mimetype);
+}
+
 export function resolveClipData(text: string | undefined): ClipData {
   if (!text) {
     throw new ClipsError('BAD_REQUEST', 'text 또는 file 중 하나는 필요합니다.');
@@ -20,8 +32,11 @@ export function resolveClipData(text: string | undefined): ClipData {
 }
 
 export function validateClipImageFile(file: MulterFile): void {
-  if (!file.mimetype.startsWith('image/')) {
-    throw new ClipsError('BAD_REQUEST', '이미지 파일만 업로드할 수 있습니다.');
+  if (!isAllowedClipImageMimeType(file.mimetype)) {
+    throw new ClipsError(
+      'BAD_REQUEST',
+      'jpeg, png, webp, gif, avif 이미지만 업로드할 수 있습니다.',
+    );
   }
 }
 

--- a/src/clips/application/usecases/create-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/create-clip.usecase.spec.ts
@@ -262,6 +262,34 @@ describe('CreateClipUseCase', () => {
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
+  it('SVG 이미지는 업로드하지 않고 거부한다', async () => {
+    const repo = createRepository();
+    repo.findPersonalFolderById.mockResolvedValue({
+      id: 'folder-id',
+      workspaceId: 'workspace-id',
+    });
+
+    const file = {
+      mimetype: 'image/svg+xml',
+      originalname: 'vector.svg',
+      size: 100,
+    } as MulterFile;
+    const imageStorage = createImageStorage();
+
+    const usecase = new CreateClipUseCase(repo, imageStorage);
+
+    await expect(
+      usecase.execute(
+        'user-id',
+        {
+          folderId: 'folder-id',
+        },
+        file,
+      ),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(imageStorage.uploadImage).not.toHaveBeenCalled();
+  });
+
   it('text와 file이 모두 없으면 실패한다', async () => {
     const repo = createRepository();
     repo.findPersonalFolderById.mockResolvedValue({

--- a/src/clips/application/usecases/update-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/update-clip.usecase.spec.ts
@@ -209,4 +209,40 @@ describe('UpdateClipUseCase', () => {
       imageUrl: 'https://cdn.example.com/clips/user-id/file.png',
     });
   });
+
+  it('SVG 이미지는 업로드하지 않고 거부한다', async () => {
+    const repo = createRepository();
+    repo.findClipByIdForUser.mockResolvedValue({
+      id: 'clip-id',
+      type: 'TEXT',
+      folderId: 'folder-id',
+      workspaceId: 'workspace-id',
+      title: 'old-text',
+      textContent: 'old-text',
+      colorHex: null,
+      imageUrl: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    });
+    const imageStorage = createImageStorage();
+    const file = {
+      mimetype: 'image/svg+xml',
+      originalname: 'vector.svg',
+      size: 100,
+    } as MulterFile;
+
+    const usecase = new UpdateClipUseCase(repo, imageStorage);
+
+    await expect(
+      usecase.execute(
+        'user-id',
+        {
+          clipId: 'clip-id',
+        },
+        file,
+      ),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(imageStorage.uploadImage).not.toHaveBeenCalled();
+  });
 });

--- a/src/clips/infrastructure/r2-clip-image-storage.service.ts
+++ b/src/clips/infrastructure/r2-clip-image-storage.service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import { extname } from 'path';
 import { ClipsError } from '../application/errors/clips.error';
+import { isAllowedClipImageMimeType } from '../application/helpers/clip-data.helper';
 import type {
   ClipImageStoragePort,
   UploadClipImageInput,
@@ -18,7 +19,6 @@ const MIME_EXTENSION_MAP: Record<string, string> = {
   'image/png': '.png',
   'image/webp': '.webp',
   'image/gif': '.gif',
-  'image/svg+xml': '.svg',
   'image/avif': '.avif',
 };
 
@@ -27,6 +27,13 @@ export class R2ClipImageStorageService implements ClipImageStoragePort {
   constructor(private readonly configService: ConfigService) {}
 
   async uploadImage(input: UploadClipImageInput): Promise<UploadedClipImage> {
+    if (!isAllowedClipImageMimeType(input.file.mimetype)) {
+      throw new ClipsError(
+        'BAD_REQUEST',
+        'jpeg, png, webp, gif, avif 이미지만 업로드할 수 있습니다.',
+      );
+    }
+
     const maxImageBytes = this.resolveMaxImageBytes();
 
     if (input.file.size > maxImageBytes) {
@@ -76,13 +83,19 @@ export class R2ClipImageStorageService implements ClipImageStoragePort {
   }
 
   private resolveExtension(file: UploadClipImageInput['file']): string {
+    const mimeExtension = MIME_EXTENSION_MAP[file.mimetype];
+
+    if (mimeExtension) {
+      return mimeExtension;
+    }
+
     const originalExtension = extname(file.originalname).toLowerCase();
 
     if (originalExtension) {
       return originalExtension;
     }
 
-    return MIME_EXTENSION_MAP[file.mimetype] ?? '';
+    return '';
   }
 
   private resolveMaxImageBytes(): number {


### PR DESCRIPTION
## Description

사용자 업로드 이미지에서 SVG MIME을 차단하고, raster 이미지 MIME allowlist만 허용하도록 정책을 정리했습니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #94, refs #84
- Requires 없음
- Ports 없음

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- 허용 MIME을 `image/jpeg`, `image/png`, `image/webp`, `image/gif`, `image/avif`로 제한했습니다.
- `image/svg+xml`은 create/update 유스케이스에서 업로드 전에 거부됩니다.
- R2 storage adapter에도 같은 allowlist 검증을 추가해 방어적으로 차단합니다.
- R2 object key 확장자는 원본 파일명보다 검증된 MIME 기반 확장자를 우선 사용합니다.

## Performance/Scaling

MIME allowlist 검사만 추가되며 성능 영향은 없습니다.

## Testing done

- `pnpm test -- create-clip.usecase.spec.ts update-clip.usecase.spec.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Additional information

- base branch: `dev`
- SVG 지원이 필요해질 경우 sanitizing/CSP/CDN origin 분리 정책을 별도 이슈로 설계하는 것이 안전합니다.


## 리뷰용 요약

### 문제 정의
사용자 업로드 이미지에서 SVG가 허용되면 script/event handler 등을 통한 XSS나 콘텐츠 보안 정책 우회 위험이 생길 수 있었습니다.

### 해결 방법 구성
MVP 기준으로 SVG는 지원하지 않고, 안전한 raster 이미지 MIME type allowlist만 허용하도록 구성했습니다.

### 해결
허용 MIME을 `jpeg`, `png`, `webp`, `gif`, `avif`로 제한하고, usecase와 R2 adapter 양쪽에서 같은 정책으로 검증하도록 변경했습니다.

### 결과
SVG 업로드는 거부되고, 허용된 raster 이미지 파일만 클립 이미지로 업로드됩니다.