### PR TITLE
#97/docs(setting) : HTTP 샘플 토큰 제거

### DIFF
--- a/http/auth.http
+++ b/http/auth.http
@@ -16,8 +16,8 @@
 ############################################################
 
 @baseUrl = http://localhost:3000
-@accessToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbWt3OXh1YzAwMDAwZ2RmaGNpeGZ0YmVvIiwiYWNjb3VudElkIjoiY21rdzl4dWMwMDAwMWdkZmg2Z2R0bzc0cyIsInBsYXRmb3JtIjoiV0VCIiwiaWF0IjoxNzY5NDk4ODY5LCJleHAiOjE3Njk0OTk3NjksImF1ZCI6ImFwaSIsImlzcyI6ImVhc3ktY2xpcCJ9.vMbNhufv5nnxSC9t_HIQvEq7I686KFkgS1_Bi2qTkMI
-@refreshToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbWtxcHNyamswMDAwZ2RkYTc1Znpob24xIiwiYWNjb3VudElkIjoiY21rcXBzcmprMDAwMWdkZGF2YnNnNWdyaiIsInBsYXRmb3JtIjoiV0VCIiwiaWF0IjoxNzY5MTYyNzQ2LCJleHAiOjE3NzAzNzIzNDYsImF1ZCI6InJlZnJlc2giLCJpc3MiOiJlYXN5LWNsaXAifQ.qcV4UMPQpQc0EPaMwVf8ROTVEON-MBp9Lk2f-pJREtA
+@accessToken = REPLACE_WITH_ACCESS_TOKEN
+@refreshToken = REPLACE_WITH_REFRESH_TOKEN
 
 @authAccountId = REPLACE_WITH_AUTH_ACCOUNT_ID
 

--- a/http/clips.http
+++ b/http/clips.http
@@ -1,6 +1,6 @@
 @baseUrl = http://localhost:3000
 # 액세스 토큰을 입력하세요
-@accessToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbWxpM3l2eTQwMDAwZ2RkNmp5dDVseGFlIiwiYWNjb3VudElkIjoiY21saTN5dnk0MDAwMWdkZDZuc3I0NWo2eSIsInBsYXRmb3JtIjoiV0VCIiwiaWF0IjoxNzcwOTA1MTAxLCJleHAiOjE3NzA5MDYwMDEsImF1ZCI6ImFwaSIsImlzcyI6ImVhc3ktY2xpcCJ9.82ZBjJX58iQrRnpPXX64M1ipmKm0x_JGezOS_ALZb5Y
+@accessToken = REPLACE_WITH_ACCESS_TOKEN
 
 
 # 테스트에 사용할 폴더 ID를 입력하세요

--- a/http/forder.http
+++ b/http/forder.http
@@ -1,6 +1,6 @@
 @baseUrl = http://localhost:3000
 # 액세스 토큰을 입력하세요
-@accessToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbWt3OXh1YzAwMDAwZ2RmaGNpeGZ0YmVvIiwiYWNjb3VudElkIjoiY21rdzl4dWMwMDAwMWdkZmg2Z2R0bzc0cyIsInBsYXRmb3JtIjoiV0VCIiwiaWF0IjoxNzY5Njc2OTQ5LCJleHAiOjE3Njk2Nzc4NDksImF1ZCI6ImFwaSIsImlzcyI6ImVhc3ktY2xpcCJ9.2-sOtRCqsri6-QsYhj_JazXhm3fuK2mfmfn3lehxpBw
+@accessToken = REPLACE_WITH_ACCESS_TOKEN
 
 ### 폴더 A 생성
 # @name createFolderA

--- a/http/user.http
+++ b/http/user.http
@@ -1,5 +1,5 @@
 @baseUrl = http://localhost:3000
-@accessToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbWxxb2JhOHYwMDAwZ2RraXgza3EzaG43IiwiYWNjb3VudElkIjoiY21scW9iYTh2MDAwMWdka2lrd2gxOTkxMSIsInBsYXRmb3JtIjoiV0VCIiwiaWF0IjoxNzcxMzM2OTk3LCJleHAiOjE3NzEzMzc4OTcsImF1ZCI6ImFwaSIsImlzcyI6ImVhc3ktY2xpcCJ9.fdAgsZBpHDTgUkwBSAlLeDwP3X-4lxdMq1grN81Egg0
+@accessToken = REPLACE_WITH_ACCESS_TOKEN
 
 ############################################################
 # User API Test (#33)

--- a/http/workspaces.http
+++ b/http/workspaces.http
@@ -1,6 +1,6 @@
 @baseUrl = http://localhost:3000
 # 액세스 토큰을 입력하세요
-@accessToken = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbWxyb2IzZW4wMDAwZ2RheXNzaHY0ZTFxIiwiYWNjb3VudElkIjoiY21scm9iM2VuMDAwMWdkYXl2OGtmYTM1MSIsInBsYXRmb3JtIjoiV0VCIiwiaWF0IjoxNzcxMzk3NDU0LCJleHAiOjE3NzEzOTgzNTQsImF1ZCI6ImFwaSIsImlzcyI6ImVhc3ktY2xpcCJ9.SIdlhVjqDe0qTqpCn-7KAI9uFWh4mh3aNqMdRoeHxpo
+@accessToken = REPLACE_WITH_ACCESS_TOKEN
 
 
 ############################################################


### PR DESCRIPTION
## Description

HTTP REST Client 샘플에 포함된 하드코딩 access/refresh JWT를 placeholder로 교체했습니다.

## Type of change

- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)

## Linked tickets and other PRs

- Closes #97, refs #84

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `http/auth.http`의 access token과 refresh token을 각각 `REPLACE_WITH_ACCESS_TOKEN`, `REPLACE_WITH_REFRESH_TOKEN`으로 교체했습니다.
- `http/clips.http`, `http/forder.http`, `http/user.http`, `http/workspaces.http`의 access token을 `REPLACE_WITH_ACCESS_TOKEN`으로 교체했습니다.
- base URL, 동적 response 변수, 기존 ID 예시는 토큰 제거 범위가 아니라서 유지했습니다.

## Performance/Scaling

해당 없음.

## Testing done

- `rg "eyJ" http -n`
- `rg "@accessToken =|@refreshToken =" http -n`

## Additional information

- 문서 샘플 변경이라 별도 런타임 테스트는 수행하지 않았습니다.


## 리뷰용 요약

### 문제 정의
HTTP 요청 샘플 파일에 실제 JWT 형태의 access/refresh token이 하드코딩되어 있어 credential 형태의 값이 저장소에 남아 있었습니다.

### 해결 방법 구성
샘플 파일의 토큰 값만 placeholder로 교체하고, base URL이나 테스트 ID 같은 비토큰 예시는 유지했습니다.

### 해결
`http/*.http`의 access token과 refresh token 값을 `REPLACE_WITH_ACCESS_TOKEN`, `REPLACE_WITH_REFRESH_TOKEN`으로 교체했습니다.

### 결과
저장소 샘플 파일에 JWT 본문이 남지 않고, 로컬 사용자는 자신의 토큰을 직접 채워 테스트할 수 있습니다.