### PR TITLE
#90/refactor(setting) : 이름 입력값 검증 강화

### DIFF
--- a/src/folders/application/constants/folder-name.constants.ts
+++ b/src/folders/application/constants/folder-name.constants.ts
@@ -1,2 +1,2 @@
-export const FOLDER_NAME_MAX_LENGTH = 50;
-export const FOLDER_TAG_NAME_MAX_LENGTH = 30;
+export const FOLDER_NAME_MAX_LENGTH = 10;
+export const FOLDER_TAG_NAME_MAX_LENGTH = 10;

--- a/src/folders/application/constants/folder-name.constants.ts
+++ b/src/folders/application/constants/folder-name.constants.ts
@@ -1,0 +1,2 @@
+export const FOLDER_NAME_MAX_LENGTH = 50;
+export const FOLDER_TAG_NAME_MAX_LENGTH = 30;

--- a/src/folders/application/helpers/folder-name.helper.ts
+++ b/src/folders/application/helpers/folder-name.helper.ts
@@ -1,0 +1,32 @@
+import { normalizeBoundedName } from '../../../shared/application/name-normalization.helper';
+import {
+  FOLDER_NAME_MAX_LENGTH,
+  FOLDER_TAG_NAME_MAX_LENGTH,
+} from '../constants/folder-name.constants';
+import { FoldersError } from '../errors/folders.error';
+
+export function normalizeFolderName(name: string): string {
+  const result = normalizeBoundedName(name, FOLDER_NAME_MAX_LENGTH);
+
+  if (!result.ok) {
+    throw new FoldersError(
+      'BAD_REQUEST',
+      `폴더명은 1자 이상 ${FOLDER_NAME_MAX_LENGTH}자 이하여야 합니다.`,
+    );
+  }
+
+  return result.value;
+}
+
+export function normalizeFolderTagName(name: string): string {
+  const result = normalizeBoundedName(name, FOLDER_TAG_NAME_MAX_LENGTH);
+
+  if (!result.ok) {
+    throw new FoldersError(
+      'BAD_REQUEST',
+      `태그명은 1자 이상 ${FOLDER_TAG_NAME_MAX_LENGTH}자 이하여야 합니다.`,
+    );
+  }
+
+  return result.value;
+}

--- a/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
@@ -77,7 +77,7 @@ describe('CreateFolderTagUseCase', () => {
     expect(repo.findPersonalFolderById).not.toHaveBeenCalled();
   });
 
-  it('태그명이 30자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+  it('태그명이 10자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
     const repo = createRepository();
 
     const usecase = new CreateFolderTagUseCase(repo);
@@ -85,7 +85,7 @@ describe('CreateFolderTagUseCase', () => {
     await expect(
       usecase.execute('user-id', {
         folderId: 'folder-id',
-        name: 'a'.repeat(31),
+        name: 'a'.repeat(11),
       }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 

--- a/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
@@ -48,6 +48,50 @@ describe('CreateFolderTagUseCase', () => {
     ).rejects.toMatchObject({ code: 'CONFLICT' });
   });
 
+  it('정규화된 태그명 기준으로 중복을 검사한다', async () => {
+    const repo = createRepository();
+    repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
+    repo.findTagByNameInFolder.mockResolvedValue({ id: 'tag-id' } as never);
+
+    const usecase = new CreateFolderTagUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', { folderId: 'folder-id', name: ' backend ' }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect(repo.findTagByNameInFolder).toHaveBeenCalledWith(
+      'folder-id',
+      'backend',
+    );
+  });
+
+  it('trim 후 태그명이 비어있으면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+
+    const usecase = new CreateFolderTagUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', { folderId: 'folder-id', name: '   ' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.findPersonalFolderById).not.toHaveBeenCalled();
+  });
+
+  it('태그명이 30자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+
+    const usecase = new CreateFolderTagUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        folderId: 'folder-id',
+        name: 'a'.repeat(31),
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.findPersonalFolderById).not.toHaveBeenCalled();
+  });
+
   it('폴더 태그를 생성한다', async () => {
     const repo = createRepository();
     repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
@@ -61,7 +105,7 @@ describe('CreateFolderTagUseCase', () => {
     const usecase = new CreateFolderTagUseCase(repo);
     const result = await usecase.execute('user-id', {
       folderId: 'folder-id',
-      name: 'backend',
+      name: ' backend ',
     });
 
     expect(repo.createFolderTag).toHaveBeenCalledWith({

--- a/src/folders/application/usecases/create-folder-tag.usecase.ts
+++ b/src/folders/application/usecases/create-folder-tag.usecase.ts
@@ -4,6 +4,7 @@ import type { FoldersRepository } from '../../domain/folders.repository';
 import type { FolderTagOutput } from '../dtos/folder-tag-output.dto';
 import { CreateFolderTagInput } from '../dtos/create-folder-tag-input.dto';
 import { FoldersError } from '../errors/folders.error';
+import { normalizeFolderTagName } from '../helpers/folder-name.helper';
 
 @Injectable()
 export class CreateFolderTagUseCase {
@@ -16,6 +17,7 @@ export class CreateFolderTagUseCase {
     userId: string,
     input: CreateFolderTagInput,
   ): Promise<FolderTagOutput> {
+    const name = normalizeFolderTagName(input.name);
     const folder = await this.foldersRepository.findPersonalFolderById(
       userId,
       input.folderId,
@@ -27,7 +29,7 @@ export class CreateFolderTagUseCase {
 
     const existingTag = await this.foldersRepository.findTagByNameInFolder(
       folder.id,
-      input.name,
+      name,
     );
 
     if (existingTag) {
@@ -36,7 +38,7 @@ export class CreateFolderTagUseCase {
 
     return this.foldersRepository.createFolderTag({
       folderId: folder.id,
-      name: input.name,
+      name,
     });
   }
 }

--- a/src/folders/application/usecases/create-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder.usecase.spec.ts
@@ -42,6 +42,46 @@ describe('CreateFolderUseCase', () => {
     expect(result).toEqual({ id: 'folder-id' });
   });
 
+  it('폴더명을 trim한 값으로 생성한다', async () => {
+    const repo = createRepository();
+    repo.getOrCreatePersonalWorkspaceId.mockResolvedValue('workspace-id');
+    repo.findLastFolderOrder.mockResolvedValue(null);
+    repo.createFolder.mockResolvedValue({ id: 'folder-id' } as never);
+
+    const usecase = new CreateFolderUseCase(repo);
+    await usecase.execute('user-id', { name: '  Inbox  ' });
+
+    expect(repo.createFolder).toHaveBeenCalledWith({
+      name: 'Inbox',
+      order: 1,
+      workspaceId: 'workspace-id',
+    });
+  });
+
+  it('trim 후 폴더명이 비어있으면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+
+    const usecase = new CreateFolderUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', { name: '   ' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.getOrCreatePersonalWorkspaceId).not.toHaveBeenCalled();
+  });
+
+  it('폴더명이 50자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+
+    const usecase = new CreateFolderUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', { name: '가'.repeat(51) }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.getOrCreatePersonalWorkspaceId).not.toHaveBeenCalled();
+  });
+
   it('마지막 폴더가 없으면 기본 순서를 사용한다', async () => {
     const repo = createRepository();
     repo.getOrCreatePersonalWorkspaceId.mockResolvedValue('workspace-id');

--- a/src/folders/application/usecases/create-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder.usecase.spec.ts
@@ -70,13 +70,13 @@ describe('CreateFolderUseCase', () => {
     expect(repo.getOrCreatePersonalWorkspaceId).not.toHaveBeenCalled();
   });
 
-  it('폴더명이 50자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+  it('폴더명이 10자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
     const repo = createRepository();
 
     const usecase = new CreateFolderUseCase(repo);
 
     await expect(
-      usecase.execute('user-id', { name: '가'.repeat(51) }),
+      usecase.execute('user-id', { name: '가'.repeat(11) }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 
     expect(repo.getOrCreatePersonalWorkspaceId).not.toHaveBeenCalled();

--- a/src/folders/application/usecases/create-folder.usecase.ts
+++ b/src/folders/application/usecases/create-folder.usecase.ts
@@ -3,6 +3,7 @@ import { FOLDERS_REPOSITORY } from '../../domain/folders.repository';
 import type { FoldersRepository } from '../../domain/folders.repository';
 import { CreateFolderInput } from '../dtos/create-folder-input.dto';
 import { FolderOutput } from '../dtos/folder-output.dto';
+import { normalizeFolderName } from '../helpers/folder-name.helper';
 
 @Injectable()
 export class CreateFolderUseCase {
@@ -15,6 +16,7 @@ export class CreateFolderUseCase {
     userId: string,
     input: CreateFolderInput,
   ): Promise<FolderOutput> {
+    const name = normalizeFolderName(input.name);
     const workspaceId =
       await this.foldersRepository.getOrCreatePersonalWorkspaceId(userId);
 
@@ -23,7 +25,7 @@ export class CreateFolderUseCase {
     const nextOrder = lastOrder ? lastOrder + 1 : 1;
 
     return this.foldersRepository.createFolder({
-      name: input.name,
+      name,
       order: nextOrder,
       workspaceId,
     });

--- a/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
@@ -79,6 +79,66 @@ describe('UpdateFolderTagUseCase', () => {
     ).rejects.toMatchObject({ code: 'CONFLICT' });
   });
 
+  it('정규화된 태그명 기준으로 중복을 검사한다', async () => {
+    const repo = createRepository();
+    repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
+    repo.findTagByIdInFolder.mockResolvedValue({
+      id: 'tag-id',
+      name: 'backend',
+    } as never);
+    repo.findTagByNameInFolder.mockResolvedValue({
+      id: 'other-tag-id',
+      name: 'frontend',
+    } as never);
+
+    const usecase = new UpdateFolderTagUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        folderId: 'folder-id',
+        tagId: 'tag-id',
+        name: ' frontend ',
+      }),
+    ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+    expect(repo.findTagByNameInFolder).toHaveBeenCalledWith(
+      'folder-id',
+      'frontend',
+    );
+  });
+
+  it('trim 후 태그명이 비어있으면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+
+    const usecase = new UpdateFolderTagUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        folderId: 'folder-id',
+        tagId: 'tag-id',
+        name: '   ',
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.findPersonalFolderById).not.toHaveBeenCalled();
+  });
+
+  it('태그명이 30자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+
+    const usecase = new UpdateFolderTagUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        folderId: 'folder-id',
+        tagId: 'tag-id',
+        name: 'a'.repeat(31),
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.findPersonalFolderById).not.toHaveBeenCalled();
+  });
+
   it('이름이 같으면 기존 태그를 반환한다', async () => {
     const repo = createRepository();
     const tag = { id: 'tag-id', name: 'backend', folderId: 'folder-id' };
@@ -116,7 +176,7 @@ describe('UpdateFolderTagUseCase', () => {
     await usecase.execute('user-id', {
       folderId: 'folder-id',
       tagId: 'tag-id',
-      name: 'frontend',
+      name: ' frontend ',
     });
 
     expect(repo.updateFolderTagName).toHaveBeenCalledWith('tag-id', 'frontend');

--- a/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
@@ -123,7 +123,7 @@ describe('UpdateFolderTagUseCase', () => {
     expect(repo.findPersonalFolderById).not.toHaveBeenCalled();
   });
 
-  it('태그명이 30자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+  it('태그명이 10자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
     const repo = createRepository();
 
     const usecase = new UpdateFolderTagUseCase(repo);
@@ -132,7 +132,7 @@ describe('UpdateFolderTagUseCase', () => {
       usecase.execute('user-id', {
         folderId: 'folder-id',
         tagId: 'tag-id',
-        name: 'a'.repeat(31),
+        name: 'a'.repeat(11),
       }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 

--- a/src/folders/application/usecases/update-folder-tag.usecase.ts
+++ b/src/folders/application/usecases/update-folder-tag.usecase.ts
@@ -4,6 +4,7 @@ import type { FoldersRepository } from '../../domain/folders.repository';
 import type { FolderTagOutput } from '../dtos/folder-tag-output.dto';
 import { UpdateFolderTagInput } from '../dtos/update-folder-tag-input.dto';
 import { FoldersError } from '../errors/folders.error';
+import { normalizeFolderTagName } from '../helpers/folder-name.helper';
 
 @Injectable()
 export class UpdateFolderTagUseCase {
@@ -16,6 +17,7 @@ export class UpdateFolderTagUseCase {
     userId: string,
     input: UpdateFolderTagInput,
   ): Promise<FolderTagOutput> {
+    const name = normalizeFolderTagName(input.name);
     const folder = await this.foldersRepository.findPersonalFolderById(
       userId,
       input.folderId,
@@ -36,17 +38,17 @@ export class UpdateFolderTagUseCase {
 
     const duplicatedTag = await this.foldersRepository.findTagByNameInFolder(
       folder.id,
-      input.name,
+      name,
     );
 
     if (duplicatedTag && duplicatedTag.id !== tag.id) {
       throw new FoldersError('CONFLICT', '이미 존재하는 태그 이름입니다.');
     }
 
-    if (tag.name === input.name) {
+    if (tag.name === name) {
       return tag;
     }
 
-    return this.foldersRepository.updateFolderTagName(tag.id, input.name);
+    return this.foldersRepository.updateFolderTagName(tag.id, name);
   }
 }

--- a/src/folders/application/usecases/update-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder.usecase.spec.ts
@@ -89,7 +89,7 @@ describe('UpdateFolderUseCase', () => {
     expect(repo.updateFolderName).not.toHaveBeenCalled();
   });
 
-  it('폴더명이 50자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+  it('폴더명이 10자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
     const repo = createRepository();
     repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
 
@@ -98,7 +98,7 @@ describe('UpdateFolderUseCase', () => {
     await expect(
       usecase.execute('user-id', {
         folderId: 'folder-id',
-        name: '가'.repeat(51),
+        name: '가'.repeat(11),
       }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 

--- a/src/folders/application/usecases/update-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder.usecase.spec.ts
@@ -61,4 +61,47 @@ describe('UpdateFolderUseCase', () => {
 
     expect(repo.updateFolderName).toHaveBeenCalledWith('folder-id', 'Renamed');
   });
+
+  it('폴더명을 trim한 값으로 수정한다', async () => {
+    const repo = createRepository();
+    repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
+    repo.updateFolderName.mockResolvedValue({ id: 'folder-id' } as never);
+
+    const usecase = new UpdateFolderUseCase(repo);
+    await usecase.execute('user-id', {
+      folderId: 'folder-id',
+      name: '  Renamed  ',
+    });
+
+    expect(repo.updateFolderName).toHaveBeenCalledWith('folder-id', 'Renamed');
+  });
+
+  it('trim 후 폴더명이 비어있으면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
+
+    const usecase = new UpdateFolderUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', { folderId: 'folder-id', name: '   ' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.updateFolderName).not.toHaveBeenCalled();
+  });
+
+  it('폴더명이 50자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
+
+    const usecase = new UpdateFolderUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', {
+        folderId: 'folder-id',
+        name: '가'.repeat(51),
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.updateFolderName).not.toHaveBeenCalled();
+  });
 });

--- a/src/folders/application/usecases/update-folder.usecase.ts
+++ b/src/folders/application/usecases/update-folder.usecase.ts
@@ -4,6 +4,7 @@ import type { FoldersRepository } from '../../domain/folders.repository';
 import { FolderOutput } from '../dtos/folder-output.dto';
 import { UpdateFolderInput } from '../dtos/update-folder-input.dto';
 import { FoldersError } from '../errors/folders.error';
+import { normalizeFolderName } from '../helpers/folder-name.helper';
 
 @Injectable()
 export class UpdateFolderUseCase {
@@ -25,10 +26,12 @@ export class UpdateFolderUseCase {
       throw new FoldersError('NOT_FOUND', '폴더를 찾을 수 없습니다.');
     }
 
-    if (!input.name) {
+    if (input.name === undefined) {
       return folder;
     }
 
-    return this.foldersRepository.updateFolderName(folder.id, input.name);
+    const name = normalizeFolderName(input.name);
+
+    return this.foldersRepository.updateFolderName(folder.id, name);
   }
 }

--- a/src/folders/presentation/dtos/create-folder-tag.dto.ts
+++ b/src/folders/presentation/dtos/create-folder-tag.dto.ts
@@ -1,9 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { FOLDER_TAG_NAME_MAX_LENGTH } from '../../application/constants/folder-name.constants';
 
 export class CreateFolderTagDto {
   @ApiProperty({ example: 'backend' })
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FOLDER_TAG_NAME_MAX_LENGTH)
   name: string;
 }

--- a/src/folders/presentation/dtos/create-folder.dto.ts
+++ b/src/folders/presentation/dtos/create-folder.dto.ts
@@ -1,9 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { FOLDER_NAME_MAX_LENGTH } from '../../application/constants/folder-name.constants';
 
 export class CreateFolderDto {
   @ApiProperty({ example: '업무' })
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FOLDER_NAME_MAX_LENGTH)
   name: string;
 }

--- a/src/folders/presentation/dtos/update-folder-tag.dto.ts
+++ b/src/folders/presentation/dtos/update-folder-tag.dto.ts
@@ -1,9 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { FOLDER_TAG_NAME_MAX_LENGTH } from '../../application/constants/folder-name.constants';
 
 export class UpdateFolderTagDto {
   @ApiProperty({ example: 'frontend' })
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FOLDER_TAG_NAME_MAX_LENGTH)
   name: string;
 }

--- a/src/folders/presentation/dtos/update-folder.dto.ts
+++ b/src/folders/presentation/dtos/update-folder.dto.ts
@@ -1,10 +1,16 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { FOLDER_NAME_MAX_LENGTH } from '../../application/constants/folder-name.constants';
 
 export class UpdateFolderDto {
   @ApiPropertyOptional({ example: '개인' })
   @IsOptional()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FOLDER_NAME_MAX_LENGTH)
   name?: string;
 }

--- a/src/shared/application/name-normalization.helper.ts
+++ b/src/shared/application/name-normalization.helper.ts
@@ -1,0 +1,22 @@
+export type NormalizeBoundedNameFailureReason = 'EMPTY' | 'TOO_LONG';
+
+export type NormalizeBoundedNameResult =
+  | { ok: true; value: string }
+  | { ok: false; reason: NormalizeBoundedNameFailureReason };
+
+export function normalizeBoundedName(
+  value: string,
+  maxLength: number,
+): NormalizeBoundedNameResult {
+  const normalized = value.trim();
+
+  if (normalized.length === 0) {
+    return { ok: false, reason: 'EMPTY' };
+  }
+
+  if (Array.from(normalized).length > maxLength) {
+    return { ok: false, reason: 'TOO_LONG' };
+  }
+
+  return { ok: true, value: normalized };
+}

--- a/src/users/application/constants/user-profile.constants.ts
+++ b/src/users/application/constants/user-profile.constants.ts
@@ -1,1 +1,1 @@
-export const DISPLAY_NAME_MAX_LENGTH = 50;
+export const DISPLAY_NAME_MAX_LENGTH = 30;

--- a/src/users/application/constants/user-profile.constants.ts
+++ b/src/users/application/constants/user-profile.constants.ts
@@ -1,0 +1,1 @@
+export const DISPLAY_NAME_MAX_LENGTH = 50;

--- a/src/users/application/helpers/update-me.helper.ts
+++ b/src/users/application/helpers/update-me.helper.ts
@@ -2,6 +2,8 @@ import { UpdateAuthAccountProfileParams } from '../../domain/users.repository';
 import { UserAuthAccount, UserWithAuthAccounts } from '../../domain/user.types';
 import { UsersError } from '../errors/users.error';
 import { UpdateMeInput } from '../dtos/update-me-input.dto';
+import { normalizeBoundedName } from '../../../shared/application/name-normalization.helper';
+import { DISPLAY_NAME_MAX_LENGTH } from '../constants/user-profile.constants';
 
 export function resolveCurrentAuthAccount(
   user: UserWithAuthAccounts,
@@ -26,7 +28,19 @@ export function buildUpdateMeParams(
   const params: UpdateAuthAccountProfileParams = {};
 
   if (input.displayName !== undefined) {
-    params.displayName = input.displayName;
+    const result = normalizeBoundedName(
+      input.displayName,
+      DISPLAY_NAME_MAX_LENGTH,
+    );
+
+    if (!result.ok) {
+      throw new UsersError(
+        'BAD_REQUEST',
+        `displayName은 1자 이상 ${DISPLAY_NAME_MAX_LENGTH}자 이하여야 합니다.`,
+      );
+    }
+
+    params.displayName = result.value;
   }
 
   if (input.avatarUrl !== undefined) {

--- a/src/users/application/usecases/update-me.usecase.spec.ts
+++ b/src/users/application/usecases/update-me.usecase.spec.ts
@@ -185,7 +185,7 @@ describe('UpdateMeUseCase', () => {
     expect(repo.updateAuthAccountProfile).not.toHaveBeenCalled();
   });
 
-  it('displayName이 50자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+  it('displayName이 30자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
     const repo = createRepository();
     repo.findUserWithAuthAccounts.mockResolvedValue({
       id: 'user-id',
@@ -204,7 +204,7 @@ describe('UpdateMeUseCase', () => {
 
     await expect(
       usecase.execute('user-id', 'account-id', {
-        displayName: '가'.repeat(51),
+        displayName: '가'.repeat(31),
       }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
 

--- a/src/users/application/usecases/update-me.usecase.spec.ts
+++ b/src/users/application/usecases/update-me.usecase.spec.ts
@@ -129,6 +129,88 @@ describe('UpdateMeUseCase', () => {
     expect(result.avatarUrl).toBeNull();
   });
 
+  it('displayName을 trim한 값으로 수정한다', async () => {
+    const repo = createRepository();
+    repo.findUserWithAuthAccounts.mockResolvedValue({
+      id: 'user-id',
+      authAccounts: [
+        {
+          id: 'account-id',
+          provider: 'GOOGLE',
+          email: 'test@example.com',
+          displayName: 'tester',
+          profileImageUrl: 'https://example.com/a.png',
+        },
+      ],
+    });
+    repo.updateAuthAccountProfile.mockResolvedValue({
+      id: 'account-id',
+      provider: 'GOOGLE',
+      email: 'test@example.com',
+      displayName: 'new-name',
+      profileImageUrl: 'https://example.com/a.png',
+    });
+
+    const usecase = new UpdateMeUseCase(repo);
+    await usecase.execute('user-id', 'account-id', {
+      displayName: '  new-name  ',
+    });
+
+    expect(repo.updateAuthAccountProfile).toHaveBeenCalledWith('account-id', {
+      displayName: 'new-name',
+    });
+  });
+
+  it('trim 후 displayName이 비어있으면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findUserWithAuthAccounts.mockResolvedValue({
+      id: 'user-id',
+      authAccounts: [
+        {
+          id: 'account-id',
+          provider: 'GOOGLE',
+          email: 'test@example.com',
+          displayName: 'tester',
+          profileImageUrl: 'https://example.com/a.png',
+        },
+      ],
+    });
+
+    const usecase = new UpdateMeUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', 'account-id', { displayName: '   ' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.updateAuthAccountProfile).not.toHaveBeenCalled();
+  });
+
+  it('displayName이 50자를 초과하면 BAD_REQUEST 에러를 던진다', async () => {
+    const repo = createRepository();
+    repo.findUserWithAuthAccounts.mockResolvedValue({
+      id: 'user-id',
+      authAccounts: [
+        {
+          id: 'account-id',
+          provider: 'GOOGLE',
+          email: 'test@example.com',
+          displayName: 'tester',
+          profileImageUrl: 'https://example.com/a.png',
+        },
+      ],
+    });
+
+    const usecase = new UpdateMeUseCase(repo);
+
+    await expect(
+      usecase.execute('user-id', 'account-id', {
+        displayName: '가'.repeat(51),
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(repo.updateAuthAccountProfile).not.toHaveBeenCalled();
+  });
+
   it('avatarUrl만 수정하면 displayName은 변경하지 않는다', async () => {
     const repo = createRepository();
     repo.findUserWithAuthAccounts.mockResolvedValue({

--- a/src/users/presentation/dtos/update-me.dto.ts
+++ b/src/users/presentation/dtos/update-me.dto.ts
@@ -1,17 +1,24 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   IsNotEmpty,
   IsOptional,
   IsString,
   IsUrl,
+  MaxLength,
   ValidateIf,
 } from 'class-validator';
+import { DISPLAY_NAME_MAX_LENGTH } from '../../application/constants/user-profile.constants';
 
 export class UpdateMeDto {
   @ApiPropertyOptional({ example: '홍길동' })
   @ValidateIf((_, value) => value !== undefined)
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @IsString()
   @IsNotEmpty()
+  @MaxLength(DISPLAY_NAME_MAX_LENGTH)
   displayName?: string;
 
   @ApiPropertyOptional({


### PR DESCRIPTION
## Description

폴더명, 태그명, 사용자 표시명 입력값에 trim 정규화와 길이 제한을 적용했습니다. 제한은 폴더명 10자, 태그명 10자, displayName 30자입니다.

## Type of change

- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #90, refs #84

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- 공용 이름 정규화 helper를 추가해 trim 후 빈 문자열과 길이 초과를 검증했습니다.
- 폴더명은 10자, 태그명은 10자, displayName은 30자로 제한했습니다.
- 생성/수정/중복 검사 모두 정규화된 값 기준으로 수행하도록 변경했습니다.
- HTTP DTO에도 trim transform과 max length 검증을 추가했습니다.

## Performance/Scaling

해당 없음.

## Testing done

- `pnpm test -- create-folder.usecase.spec.ts create-folder-tag.usecase.spec.ts update-folder.usecase.spec.ts update-folder-tag.usecase.spec.ts update-me.usecase.spec.ts`
- `pnpm build`

## Additional information

- base branch: `dev`
- 독립 PR입니다.


## 리뷰용 요약

### 문제 정의
폴더명, 태그명, 사용자 표시명 같은 이름 입력값이 trim/길이 검증 없이 저장되어 공백 이름이나 과도하게 긴 값, 정규화되지 않은 중복 값이 들어갈 수 있었습니다.

### 해결 방법 구성
application layer에서 이름을 정규화해 HTTP 외 호출에서도 동일하게 보장하고, DTO에는 보조 검증을 추가하는 방식으로 구성했습니다.

### 해결
폴더명 10자, 태그명 10자, displayName 30자 제한을 추가하고, 저장/중복 검사 모두 trim된 값 기준으로 수행하도록 변경했습니다.

### 결과
이름 계열 데이터가 일관된 형태로 저장되고, 공백/길이 초과/정규화 전후 중복 문제가 줄어듭니다.