### PR TITLE
#112/fix(clip) : 휴지통 고아 복원 방지

### DIFF
--- a/src/clips/infrastructure/prisma-clips.repository.ts
+++ b/src/clips/infrastructure/prisma-clips.repository.ts
@@ -47,6 +47,9 @@ export class PrismaClipsRepository implements ClipsRepository {
       where: {
         id: clipId,
         deletedAt: null,
+        folder: {
+          deletedAt: null,
+        },
         workspace: {
           ownerUserId: userId,
         },
@@ -157,6 +160,9 @@ export class PrismaClipsRepository implements ClipsRepository {
         userId,
         clip: {
           deletedAt: null,
+          folder: {
+            deletedAt: null,
+          },
           workspace: {
             ownerUserId: userId,
           },
@@ -186,6 +192,9 @@ export class PrismaClipsRepository implements ClipsRepository {
           in: clipIds,
         },
         deletedAt: null,
+        folder: {
+          deletedAt: null,
+        },
         workspace: {
           ownerUserId: userId,
         },
@@ -399,6 +408,9 @@ export class PrismaClipsRepository implements ClipsRepository {
           in: clipIds,
         },
         deletedAt: null,
+        folder: {
+          deletedAt: null,
+        },
       },
       data: { deletedAt: new Date() },
     });
@@ -410,6 +422,9 @@ export class PrismaClipsRepository implements ClipsRepository {
     const result = await this.prisma.clip.updateMany({
       where: {
         deletedAt: null,
+        folder: {
+          deletedAt: null,
+        },
         workspace: {
           ownerUserId: userId,
         },

--- a/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/create-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/delete-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/delete-folder-tag.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/delete-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/delete-folder.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });
@@ -39,13 +39,13 @@ describe('DeleteFolderUseCase', () => {
   it('폴더를 삭제한다', async () => {
     const repo = createRepository();
     repo.findPersonalFolderById.mockResolvedValue({ id: 'folder-id' } as never);
-    repo.softDeleteFolderWithClips.mockResolvedValue({
+    repo.softDeleteFolder.mockResolvedValue({
       id: 'folder-id',
     } as never);
 
     const usecase = new DeleteFolderUseCase(repo);
     await usecase.execute('user-id', 'folder-id');
 
-    expect(repo.softDeleteFolderWithClips).toHaveBeenCalledWith('folder-id');
+    expect(repo.softDeleteFolder).toHaveBeenCalledWith('folder-id');
   });
 });

--- a/src/folders/application/usecases/delete-folder.usecase.ts
+++ b/src/folders/application/usecases/delete-folder.usecase.ts
@@ -21,6 +21,6 @@ export class DeleteFolderUseCase {
       throw new FoldersError('NOT_FOUND', '폴더를 찾을 수 없습니다.');
     }
 
-    return this.foldersRepository.softDeleteFolderWithClips(folder.id);
+    return this.foldersRepository.softDeleteFolder(folder.id);
   }
 }

--- a/src/folders/application/usecases/get-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/get-folder.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/list-folder-tags.usecase.spec.ts
+++ b/src/folders/application/usecases/list-folder-tags.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/list-folders.usecase.spec.ts
+++ b/src/folders/application/usecases/list-folders.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/reorder-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/reorder-folder.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/application/usecases/update-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder.usecase.spec.ts
@@ -19,7 +19,7 @@ const createRepository = (): jest.Mocked<FoldersRepository> => ({
   updateFolderTagName: jest.fn(),
   updateFolderOrder: jest.fn(),
   deleteFolderTag: jest.fn(),
-  softDeleteFolderWithClips: jest.fn(),
+  softDeleteFolder: jest.fn(),
   findPreviousFolderOrder: jest.fn(),
   findNextFolderOrder: jest.fn(),
 });

--- a/src/folders/domain/folders.repository.ts
+++ b/src/folders/domain/folders.repository.ts
@@ -49,7 +49,7 @@ export interface FoldersRepository {
   updateFolderTagName(tagId: string, name: string): Promise<FolderTag>;
   updateFolderOrder(folderId: string, order: number): Promise<Folder>;
   deleteFolderTag(tagId: string): Promise<void>;
-  softDeleteFolderWithClips(folderId: string): Promise<Folder>;
+  softDeleteFolder(folderId: string): Promise<Folder>;
   findPreviousFolderOrder(params: FolderOrderParams): Promise<number | null>;
   findNextFolderOrder(params: FolderOrderParams): Promise<number | null>;
 }

--- a/src/folders/infrastructure/prisma-folders.repository.ts
+++ b/src/folders/infrastructure/prisma-folders.repository.ts
@@ -207,24 +207,10 @@ export class PrismaFoldersRepository implements FoldersRepository {
     });
   }
 
-  async softDeleteFolderWithClips(folderId: string): Promise<Folder> {
-    return this.prisma.$transaction(async (tx) => {
-      const deletedAt = new Date();
-
-      await tx.clip.updateMany({
-        where: {
-          folderId,
-          deletedAt: null,
-        },
-        data: {
-          deletedAt,
-        },
-      });
-
-      return tx.folder.update({
-        where: { id: folderId },
-        data: { deletedAt },
-      });
+  async softDeleteFolder(folderId: string): Promise<Folder> {
+    return this.prisma.folder.update({
+      where: { id: folderId },
+      data: { deletedAt: new Date() },
     });
   }
 

--- a/src/trash/application/usecases/delete-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/delete-trash-items.usecase.spec.ts
@@ -164,6 +164,34 @@ describe('DeleteTrashItemsUseCase', () => {
     });
   });
 
+  it('삭제된 폴더 하위 클립만 단독 영구 삭제하면 에러를 던진다', async () => {
+    const repo = createRepository();
+    const imageStorage = createImageStorage();
+    const deletedAt = new Date();
+    repo.findDeletedClipsByIds.mockResolvedValue([
+      {
+        id: 'clip-1',
+        title: '삭제된 클립',
+        type: 'TEXT',
+        folderId: 'folder-1',
+        deletedAt,
+        folderDeletedAt: deletedAt,
+      },
+    ]);
+    repo.findDeletedFoldersByIds.mockResolvedValue([]);
+
+    const usecase = new DeleteTrashItemsUseCase(repo, imageStorage);
+
+    await expect(
+      usecase.execute('user-1', {
+        items: [{ itemType: 'CLIP', id: 'clip-1' }],
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+    expect(repo.hardDeleteItems).not.toHaveBeenCalled();
+  });
+
   it('요청한 휴지통 항목이 없으면 에러를 던진다', async () => {
     const repo = createRepository();
     const imageStorage = createImageStorage();

--- a/src/trash/application/usecases/delete-trash-items.usecase.ts
+++ b/src/trash/application/usecases/delete-trash-items.usecase.ts
@@ -56,6 +56,17 @@ export class DeleteTrashItemsUseCase {
     }
 
     const deleteFolderIds = new Set(folderIds);
+    const blockedClip = clips.find(
+      (clip) => clip.folderDeletedAt && !deleteFolderIds.has(clip.folderId),
+    );
+
+    if (blockedClip) {
+      throw new TrashError(
+        'CONFLICT',
+        '삭제된 폴더에 속한 클립은 단독으로 영구 삭제할 수 없습니다.',
+      );
+    }
+
     const deleteClipIds = clips
       .filter((clip) => !deleteFolderIds.has(clip.folderId))
       .map((clip) => clip.id);

--- a/src/trash/application/usecases/restore-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/restore-trash-items.usecase.spec.ts
@@ -84,7 +84,7 @@ describe('RestoreTrashItemsUseCase', () => {
     expect(result).toEqual({ restoredCount: 2 });
   });
 
-  it('같은 요청의 폴더에 속한 클립은 폴더 복구로 함께 처리한다', async () => {
+  it('같은 요청의 폴더에 속한 클립은 폴더와 함께 명시적으로 복구한다', async () => {
     const repo = createRepository();
     const deletedAt = new Date();
     repo.findDeletedClipsByIds.mockResolvedValue([
@@ -115,7 +115,7 @@ describe('RestoreTrashItemsUseCase', () => {
 
     expect(repo.restoreItems).toHaveBeenCalledWith({
       userId: 'user-1',
-      clipIds: [],
+      clipIds: ['clip-1'],
       folderIds: ['folder-1'],
     });
     expect(result).toEqual({ restoredCount: 2 });

--- a/src/trash/application/usecases/restore-trash-items.usecase.ts
+++ b/src/trash/application/usecases/restore-trash-items.usecase.ts
@@ -59,9 +59,7 @@ export class RestoreTrashItemsUseCase {
       );
     }
 
-    const restoreClipIds = clips
-      .filter((clip) => !restoreFolderIds.has(clip.folderId))
-      .map((clip) => clip.id);
+    const restoreClipIds = clips.map((clip) => clip.id);
 
     await this.trashRepository.restoreItems({
       userId,

--- a/src/trash/infrastructure/prisma-trash.repository.ts
+++ b/src/trash/infrastructure/prisma-trash.repository.ts
@@ -34,6 +34,9 @@ export class PrismaTrashRepository implements TrashRepository {
           deletedAt: {
             not: null,
           },
+          folder: {
+            deletedAt: null,
+          },
           ...(cursor ? { OR: buildClipTrashCursorWhere(cursor) } : {}),
           workspace: {
             ownerUserId: params.userId,
@@ -173,23 +176,6 @@ export class PrismaTrashRepository implements TrashRepository {
   async restoreItems(params: RestoreTrashItemsParams): Promise<void> {
     await this.prisma.$transaction(async (tx) => {
       if (params.folderIds.length > 0) {
-        await tx.clip.updateMany({
-          where: {
-            folderId: {
-              in: params.folderIds,
-            },
-            deletedAt: {
-              not: null,
-            },
-            workspace: {
-              ownerUserId: params.userId,
-            },
-          },
-          data: {
-            deletedAt: null,
-          },
-        });
-
         await tx.folder.updateMany({
           where: {
             id: {
@@ -219,6 +205,9 @@ export class PrismaTrashRepository implements TrashRepository {
             },
             workspace: {
               ownerUserId: params.userId,
+            },
+            folder: {
+              deletedAt: null,
             },
           },
           data: {
@@ -634,6 +623,9 @@ export class PrismaTrashRepository implements TrashRepository {
           id: parsedCursor.id,
           deletedAt: {
             not: null,
+          },
+          folder: {
+            deletedAt: null,
           },
           workspace: {
             ownerUserId: params.userId,


### PR DESCRIPTION
## Description

휴지통에서 폴더와 하위 클립의 삭제 상태를 분리해 계층형 데이터 복원 시 고아 복원이 발생하지 않도록 개선했습니다.

기존에는 폴더 삭제 시 하위 클립에도 `deletedAt`이 함께 기록되어, 삭제된 폴더 하위 클립이 휴지통 단건 항목처럼 취급될 수 있었습니다. 이로 인해 상위 폴더가 삭제된 상태에서 하위 클립만 복원되는 등 사용자 기대와 다른 상태가 발생할 수 있었습니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #112

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- 폴더 삭제 시 하위 클립의 `deletedAt`을 변경하지 않고 폴더만 소프트 삭제하도록 변경했습니다.
- 활성 클립 조회, 최근 조회, 다중/전체 클립 삭제 경로에 활성 폴더 조건을 보강했습니다.
- 휴지통 클립 목록과 커서 조회에서 삭제된 폴더 하위 클립을 제외했습니다.
- 폴더 복원 시 하위 클립을 자동 복원하지 않도록 변경했습니다.
- 삭제된 폴더 하위 클립의 단독 복원/영구 삭제를 차단하는 유스케이스 검증을 유지 및 보강했습니다.

## Performance/Scaling

활성 클립과 휴지통 클립 조회에 폴더 삭제 상태 조건이 추가됩니다. 기존 `folderId` 관계를 활용하는 필터이며, 폴더 영구 삭제 시 하위 클립을 함께 삭제하는 기존 흐름은 유지했습니다.

## Testing done

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm test:e2e`
- `git diff --check`

## Additional information

PR은 `fix/112` 브랜치에서 `dev` 브랜치 대상으로 생성합니다.
