### PR TITLE
#116/feat(setting) : 결제 성공 및 구독 재개 메일 발송 구현

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -8,3 +8,6 @@ approval_mode = "approve"
 [mcp_servers.context7]
 command = "npx"
 args = ["-y", "@upstash/context7-mcp@latest"]
+
+[mcp_servers.resend]
+url = "https://mcp.resend.com"

--- a/.env.production.example
+++ b/.env.production.example
@@ -35,6 +35,14 @@ PRO_MONTHLY_AMOUNT=4900
 AUTO_RENEWALS_BATCH_ENABLED=false
 AUTO_RENEWALS_BATCH_SECRET=
 
+# ======================
+# Resend Mail
+# ======================
+MAIL_ENABLED=false
+RESEND_API_KEY=replace_with_resend_sending_access_api_key
+MAIL_FROM_ADDRESS="Easy Clip <noreply@easy-clip.app>"
+MAIL_SUPPORT_EMAIL=support@easy-clip.app
+
 # 운영에서 API 호출을 허용할 프론트 origin을 쉼표로 추가합니다.
 CORS_ALLOWED_ORIGINS=https://YOUR_FRONTEND_DOMAIN
 # local 개발용 localhost/127.0.0.1 포트 allowlist입니다. production에서는 사용하지 않습니다.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "passport-google-oauth20": "^2.0.0",
     "prisma": "^6.19.1",
     "reflect-metadata": "^0.2.2",
+    "resend": "^6.17.1",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
+      resend:
+        specifier: ^6.17.1
+        version: 6.17.1
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1024,6 +1027,9 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2034,6 +2040,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2914,6 +2923,9 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2994,6 +3006,15 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resend@6.17.1:
+    resolution: {integrity: sha512-QhHHIRPPM9Tq2uilWmNF8C8kd6nLkUmiFgDQCt1v4eR4o+6p86qrK+Vn12jnAs0jR8Gf6ABdxI18/90LGQ7GVA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -3120,6 +3141,9 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -4706,6 +4730,8 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tokenizer/inflate@0.4.1':
@@ -5781,6 +5807,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fast-xml-builder@1.2.0:
@@ -6815,6 +6843,8 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  postal-mime@2.7.4: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -6886,6 +6916,11 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  resend@6.17.1:
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -7035,6 +7070,11 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 

--- a/src/auth/presentation/strategies/github.strategy.ts
+++ b/src/auth/presentation/strategies/github.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 import { AuthProvider } from 'src/shared/types/auth-provider.type';
@@ -14,6 +14,8 @@ import {
 
 @Injectable()
 export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
+  private readonly logger = new Logger(GithubStrategy.name);
+
   constructor(private readonly config: ConfigService) {
     super({
       clientID: config.getOrThrow<string>('GITHUB_CLIENT_ID'),
@@ -33,20 +35,21 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
     });
   }
 
-  validate(
+  async validate(
     req: Request,
     accessToken: string,
     refreshToken: string,
     profile: Profile,
-  ): OAuthUser {
+  ): Promise<OAuthUser> {
     const state = parseOAuthState(req.query.state as string | undefined, {
       secret: resolveOAuthStateSecret(this.config),
     });
+    const email = await this.resolveEmail(accessToken, profile);
 
     return {
       provider: AuthProvider.GITHUB,
       providerUserId: profile.id,
-      email: profile.emails?.[0]?.value,
+      email,
       displayName: profile.displayName ?? profile.username ?? null,
       avatarUrl: profile.photos?.[0]?.value,
       mode: state.mode,
@@ -54,4 +57,62 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
       currentUserId: state.currentUserId,
     };
   }
+
+  private async resolveEmail(
+    accessToken: string,
+    profile: Profile,
+  ): Promise<string | null> {
+    // GitHub profile.emails는 private primary email이 빠질 수 있어 이메일 API 결과를 우선한다.
+    const verifiedEmail = await this.fetchVerifiedGithubEmail(accessToken);
+
+    return (
+      verifiedEmail ??
+      profile.emails?.find((email) => Boolean(email.value))?.value ??
+      null
+    );
+  }
+
+  private async fetchVerifiedGithubEmail(
+    accessToken: string,
+  ): Promise<string | null> {
+    try {
+      const response = await fetch('https://api.github.com/user/emails', {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${accessToken}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `GitHub 이메일 조회에 실패했습니다. status=${response.status}`,
+        );
+        return null;
+      }
+
+      const emails = (await response.json()) as GithubEmailResponse[];
+      const primaryVerified = emails.find(
+        (email) => email.primary && email.verified,
+      );
+      const verifiedFallback = emails.find((email) => email.verified);
+
+      return primaryVerified?.email ?? verifiedFallback?.email ?? null;
+    } catch (error) {
+      this.logger.warn(
+        `GitHub 이메일 조회 중 오류가 발생했습니다. message=${resolveErrorMessage(error)}`,
+      );
+      return null;
+    }
+  }
+}
+
+type GithubEmailResponse = {
+  email: string;
+  primary: boolean;
+  verified: boolean;
+};
+
+function resolveErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'unknown';
 }

--- a/src/subscriptions/application/ports/subscription-payment-mail.port.ts
+++ b/src/subscriptions/application/ports/subscription-payment-mail.port.ts
@@ -1,0 +1,22 @@
+import { SubscriptionPlan } from '../../domain/subscription.types';
+
+export const SUBSCRIPTION_PAYMENT_MAIL_PORT = Symbol(
+  'SUBSCRIPTION_PAYMENT_MAIL_PORT',
+);
+
+export type SendSubscriptionPaymentSuccessMailInput = {
+  recipientEmail: string;
+  amount: number;
+  currency: string;
+  approvedAt: Date;
+  plan: SubscriptionPlan;
+  currentPeriodEnd: Date;
+  nextBillingAt: Date;
+  paymentKind: 'INITIAL' | 'AUTO_RENEWAL';
+};
+
+export interface SubscriptionPaymentMailPort {
+  sendPaymentSuccess(
+    input: SendSubscriptionPaymentSuccessMailInput,
+  ): Promise<void>;
+}

--- a/src/subscriptions/application/ports/subscription-payment-mail.port.ts
+++ b/src/subscriptions/application/ports/subscription-payment-mail.port.ts
@@ -15,8 +15,19 @@ export type SendSubscriptionPaymentSuccessMailInput = {
   paymentKind: 'INITIAL' | 'AUTO_RENEWAL';
 };
 
+export type SendSubscriptionResumedMailInput = {
+  recipientEmail: string;
+  plan: SubscriptionPlan;
+  currentPeriodEnd: Date;
+  nextBillingAt: Date;
+};
+
 export interface SubscriptionPaymentMailPort {
   sendPaymentSuccess(
     input: SendSubscriptionPaymentSuccessMailInput,
+  ): Promise<void>;
+
+  sendSubscriptionResumed(
+    input: SendSubscriptionResumedMailInput,
   ): Promise<void>;
 }

--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
@@ -47,6 +47,7 @@ const createGateway = (): jest.Mocked<BillingPaymentGateway> => ({
 
 const createMailer = (): jest.Mocked<SubscriptionPaymentMailPort> => ({
   sendPaymentSuccess: jest.fn(),
+  sendSubscriptionResumed: jest.fn(),
 });
 
 const createConfig = () =>
@@ -236,6 +237,9 @@ describe('ConfirmBillingAuthUseCase', () => {
         externalCustomerKey: 'customer-key',
       }),
     );
+    repo.findBillingMailRecipientByUserId.mockResolvedValue({
+      email: 'user@example.com',
+    });
 
     const usecase = new ConfirmBillingAuthUseCase(
       repo,
@@ -253,6 +257,12 @@ describe('ConfirmBillingAuthUseCase', () => {
     expect(repo.activateByPayment).not.toHaveBeenCalled();
     expect(repo.recordPaymentFailure).not.toHaveBeenCalled();
     expect(mailer.sendPaymentSuccess).not.toHaveBeenCalled();
+    expect(mailer.sendSubscriptionResumed).toHaveBeenCalledWith({
+      recipientEmail: 'user@example.com',
+      plan: SubscriptionPlan.PRO,
+      currentPeriodEnd,
+      nextBillingAt: currentPeriodEnd,
+    });
     expect(repo.updateSubscription).toHaveBeenCalledWith('subscription-id', {
       status: SubscriptionStatus.ACTIVE,
       autoRenew: true,
@@ -374,6 +384,62 @@ describe('ConfirmBillingAuthUseCase', () => {
     ).resolves.toMatchObject({
       plan: SubscriptionPlan.PRO,
       status: SubscriptionStatus.ACTIVE,
+    });
+  });
+
+  it('구독 재개 메일 발송 실패가 즉시 결제 없는 재개 응답을 막지 않는다', async () => {
+    const repo = createRepository();
+    const gateway = createGateway();
+    const mailer = createMailer();
+    const currentPeriodEnd = new Date('2099-04-01T00:00:00.000Z');
+
+    repo.getOrCreatePersonalSubscription.mockResolvedValue(
+      createSubscription({
+        plan: SubscriptionPlan.PRO,
+        status: SubscriptionStatus.CANCELED,
+        autoRenew: false,
+        startedAt: new Date('2026-02-01T00:00:00.000Z'),
+        currentPeriodEnd,
+        nextBillingAt: null,
+        externalBillingKey: 'billing-key',
+        externalCustomerKey: 'customer-key',
+      }),
+    );
+    repo.updateSubscription.mockResolvedValue(
+      createSubscription({
+        plan: SubscriptionPlan.PRO,
+        status: SubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        startedAt: new Date('2026-02-01T00:00:00.000Z'),
+        currentPeriodEnd,
+        nextBillingAt: currentPeriodEnd,
+        externalBillingKey: 'billing-key',
+        externalCustomerKey: 'customer-key',
+      }),
+    );
+    repo.findBillingMailRecipientByUserId.mockResolvedValue({
+      email: 'user@example.com',
+    });
+    mailer.sendSubscriptionResumed.mockRejectedValue(
+      new Error('resend failed'),
+    );
+
+    const usecase = new ConfirmBillingAuthUseCase(
+      repo,
+      gateway,
+      mailer,
+      createConfig(),
+    );
+
+    await expect(
+      usecase.execute('user-id', {
+        authKey: 'auth-key',
+        customerKey: 'customer-key',
+      }),
+    ).resolves.toMatchObject({
+      plan: SubscriptionPlan.PRO,
+      status: SubscriptionStatus.ACTIVE,
+      autoRenew: true,
     });
   });
 });

--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
@@ -2,6 +2,7 @@
 import { ConfigService } from '@nestjs/config';
 import { ConfirmBillingAuthUseCase } from './confirm-billing-auth.usecase';
 import { BillingPaymentGateway } from '../ports/billing-payment.gateway';
+import { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
 import { SubscriptionsRepository } from '../../domain/subscriptions.repository';
 import {
   PaymentProvider,
@@ -30,6 +31,8 @@ const createSubscription = (
 
 const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
   getOrCreatePersonalSubscription: jest.fn(),
+  findBillingMailRecipientByUserId: jest.fn(),
+  findBillingMailRecipientBySubscriptionId: jest.fn(),
   updateSubscription: jest.fn(),
   activateByPayment: jest.fn(),
   recordPaymentFailure: jest.fn(),
@@ -40,6 +43,10 @@ const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
 const createGateway = (): jest.Mocked<BillingPaymentGateway> => ({
   issueBillingKey: jest.fn(),
   chargeBilling: jest.fn(),
+});
+
+const createMailer = (): jest.Mocked<SubscriptionPaymentMailPort> => ({
+  sendPaymentSuccess: jest.fn(),
 });
 
 const createConfig = () =>
@@ -58,6 +65,7 @@ describe('ConfirmBillingAuthUseCase', () => {
   it('최초 결제 성공 시 PRO 구독을 생성하고 자동갱신을 활성화한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const approvedAt = new Date('2026-02-01T00:00:00.000Z');
     const periodEnd = new Date('2026-03-01T00:00:00.000Z');
 
@@ -91,10 +99,14 @@ describe('ConfirmBillingAuthUseCase', () => {
         nextBillingAt: periodEnd,
       }),
     );
+    repo.findBillingMailRecipientByUserId.mockResolvedValue({
+      email: 'user@example.com',
+    });
 
     const usecase = new ConfirmBillingAuthUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
     const result = await usecase.execute('user-id', {
@@ -120,11 +132,22 @@ describe('ConfirmBillingAuthUseCase', () => {
       autoRenew: true,
       nextBillingAt: periodEnd,
     });
+    expect(mailer.sendPaymentSuccess).toHaveBeenCalledWith({
+      recipientEmail: 'user@example.com',
+      amount: 4900,
+      currency: 'KRW',
+      approvedAt,
+      plan: SubscriptionPlan.PRO,
+      currentPeriodEnd: periodEnd,
+      nextBillingAt: periodEnd,
+      paymentKind: 'INITIAL',
+    });
   });
 
   it('활성 PRO 구독은 기존 만료일 뒤로 1개월 연장한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const currentPeriodEnd = new Date('2026-04-01T00:00:00.000Z');
 
     repo.getOrCreatePersonalSubscription.mockResolvedValue(
@@ -160,10 +183,14 @@ describe('ConfirmBillingAuthUseCase', () => {
         autoRenew: true,
       }),
     );
+    repo.findBillingMailRecipientByUserId.mockResolvedValue({
+      email: 'user@example.com',
+    });
 
     const usecase = new ConfirmBillingAuthUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
     await usecase.execute('user-id', {
@@ -182,6 +209,7 @@ describe('ConfirmBillingAuthUseCase', () => {
   it('남은 기간이 있는 해지 구독은 즉시 결제 없이 자동갱신만 재개한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const currentPeriodEnd = new Date('2099-04-01T00:00:00.000Z');
 
     repo.getOrCreatePersonalSubscription.mockResolvedValue(
@@ -212,6 +240,7 @@ describe('ConfirmBillingAuthUseCase', () => {
     const usecase = new ConfirmBillingAuthUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
     const result = await usecase.execute('user-id', {
@@ -223,6 +252,7 @@ describe('ConfirmBillingAuthUseCase', () => {
     expect(gateway.chargeBilling).not.toHaveBeenCalled();
     expect(repo.activateByPayment).not.toHaveBeenCalled();
     expect(repo.recordPaymentFailure).not.toHaveBeenCalled();
+    expect(mailer.sendPaymentSuccess).not.toHaveBeenCalled();
     expect(repo.updateSubscription).toHaveBeenCalledWith('subscription-id', {
       status: SubscriptionStatus.ACTIVE,
       autoRenew: true,
@@ -240,6 +270,7 @@ describe('ConfirmBillingAuthUseCase', () => {
   it('결제 실패 시 구독을 변경하지 않고 실패 이력만 저장한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
 
     repo.getOrCreatePersonalSubscription.mockResolvedValue(
       createSubscription(),
@@ -265,6 +296,7 @@ describe('ConfirmBillingAuthUseCase', () => {
     const usecase = new ConfirmBillingAuthUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
 
@@ -282,5 +314,66 @@ describe('ConfirmBillingAuthUseCase', () => {
       }),
     );
     expect(repo.activateByPayment).not.toHaveBeenCalled();
+    expect(mailer.sendPaymentSuccess).not.toHaveBeenCalled();
+  });
+
+  it('결제 성공 메일 발송 실패가 결제 성공 응답을 막지 않는다', async () => {
+    const repo = createRepository();
+    const gateway = createGateway();
+    const mailer = createMailer();
+    const approvedAt = new Date('2026-02-01T00:00:00.000Z');
+    const periodEnd = new Date('2026-03-01T00:00:00.000Z');
+
+    repo.getOrCreatePersonalSubscription.mockResolvedValue(
+      createSubscription(),
+    );
+    gateway.issueBillingKey.mockResolvedValue({
+      billingKey: 'billing-key',
+      authenticatedAt: approvedAt,
+      method: '카드',
+      rawData: {},
+    });
+    gateway.chargeBilling.mockResolvedValue({
+      paymentKey: 'payment-key',
+      orderId: 'order-id',
+      status: SubscriptionPaymentStatus.DONE,
+      totalAmount: 4900,
+      currency: 'KRW',
+      approvedAt,
+      failureCode: null,
+      failureMessage: null,
+      rawData: {},
+    });
+    repo.activateByPayment.mockResolvedValue(
+      createSubscription({
+        plan: SubscriptionPlan.PRO,
+        status: SubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        externalBillingKey: 'billing-key',
+        currentPeriodEnd: periodEnd,
+        nextBillingAt: periodEnd,
+      }),
+    );
+    repo.findBillingMailRecipientByUserId.mockResolvedValue({
+      email: 'user@example.com',
+    });
+    mailer.sendPaymentSuccess.mockRejectedValue(new Error('resend failed'));
+
+    const usecase = new ConfirmBillingAuthUseCase(
+      repo,
+      gateway,
+      mailer,
+      createConfig(),
+    );
+
+    await expect(
+      usecase.execute('user-id', {
+        authKey: 'auth-key',
+        customerKey: 'customer-key',
+      }),
+    ).resolves.toMatchObject({
+      plan: SubscriptionPlan.PRO,
+      status: SubscriptionStatus.ACTIVE,
+    });
   });
 });

--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.ts
@@ -59,6 +59,12 @@ export class ConfirmBillingAuthUseCase {
         },
       );
 
+      await this.sendSubscriptionResumedMail({
+        userId,
+        currentPeriodEnd: updated.currentPeriodEnd,
+        nextBillingAt: updated.nextBillingAt,
+      });
+
       return toMySubscriptionResponse(updated);
     }
 
@@ -176,6 +182,42 @@ export class ConfirmBillingAuthUseCase {
     } catch (error) {
       this.logger.warn(
         `결제 성공 메일 발송에 실패했습니다. userId=${input.userId} error=${resolveErrorName(error)}`,
+      );
+    }
+  }
+
+  private async sendSubscriptionResumedMail(input: {
+    userId: string;
+    currentPeriodEnd: Date | null;
+    nextBillingAt: Date | null;
+  }): Promise<void> {
+    if (!input.currentPeriodEnd || !input.nextBillingAt) {
+      return;
+    }
+
+    try {
+      const recipient =
+        await this.subscriptionsRepository.findBillingMailRecipientByUserId(
+          input.userId,
+        );
+
+      if (!recipient) {
+        this.logger.warn(
+          `구독 재개 메일 수신자를 찾지 못했습니다. userId=${input.userId}`,
+        );
+        return;
+      }
+
+      // 재개는 즉시 과금이 아니므로 결제 성공 메일과 분리해 다음 결제 예정일만 안내한다.
+      await this.subscriptionPaymentMailPort.sendSubscriptionResumed({
+        recipientEmail: recipient.email,
+        plan: SubscriptionPlan.PRO,
+        currentPeriodEnd: input.currentPeriodEnd,
+        nextBillingAt: input.nextBillingAt,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `구독 재개 메일 발송에 실패했습니다. userId=${input.userId} error=${resolveErrorName(error)}`,
       );
     }
   }

--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SUBSCRIPTIONS_REPOSITORY } from '../../domain/subscriptions.repository';
 import type { SubscriptionsRepository } from '../../domain/subscriptions.repository';
@@ -10,6 +10,8 @@ import {
 } from '../../domain/subscription.types';
 import { BILLING_PAYMENT_GATEWAY } from '../ports/billing-payment.gateway';
 import type { BillingPaymentGateway } from '../ports/billing-payment.gateway';
+import { SUBSCRIPTION_PAYMENT_MAIL_PORT } from '../ports/subscription-payment-mail.port';
+import type { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
 import { ConfirmBillingAuthInput } from '../dtos/billing-auth-output.dto';
 import { MySubscriptionOutput } from '../dtos/my-subscription-output.dto';
 import { SubscriptionsError } from '../errors/subscriptions.error';
@@ -19,11 +21,15 @@ import { toMySubscriptionResponse } from '../helpers/subscription-response.helpe
 
 @Injectable()
 export class ConfirmBillingAuthUseCase {
+  private readonly logger = new Logger(ConfirmBillingAuthUseCase.name);
+
   constructor(
     @Inject(SUBSCRIPTIONS_REPOSITORY)
     private readonly subscriptionsRepository: SubscriptionsRepository,
     @Inject(BILLING_PAYMENT_GATEWAY)
     private readonly billingPaymentGateway: BillingPaymentGateway,
+    @Inject(SUBSCRIPTION_PAYMENT_MAIL_PORT)
+    private readonly subscriptionPaymentMailPort: SubscriptionPaymentMailPort,
     private readonly configService: ConfigService,
   ) {}
 
@@ -123,7 +129,55 @@ export class ConfirmBillingAuthUseCase {
       rawData: paymentResult.rawData,
     });
 
+    await this.sendPaymentSuccessMail({
+      userId,
+      amount: paymentResult.totalAmount,
+      currency: paymentResult.currency,
+      approvedAt: paidAt,
+      currentPeriodEnd: period.currentPeriodEnd,
+      nextBillingAt: period.nextBillingAt,
+    });
+
     return toMySubscriptionResponse(updated);
+  }
+
+  private async sendPaymentSuccessMail(input: {
+    userId: string;
+    amount: number;
+    currency: string;
+    approvedAt: Date;
+    currentPeriodEnd: Date;
+    nextBillingAt: Date;
+  }): Promise<void> {
+    try {
+      const recipient =
+        await this.subscriptionsRepository.findBillingMailRecipientByUserId(
+          input.userId,
+        );
+
+      if (!recipient) {
+        this.logger.warn(
+          `결제 성공 메일 수신자를 찾지 못했습니다. userId=${input.userId}`,
+        );
+        return;
+      }
+
+      // 결제 DB 반영은 이미 완료된 상태이므로, 메일 실패는 결제 성공 응답을 롤백하지 않는다.
+      await this.subscriptionPaymentMailPort.sendPaymentSuccess({
+        recipientEmail: recipient.email,
+        amount: input.amount,
+        currency: input.currency,
+        approvedAt: input.approvedAt,
+        plan: SubscriptionPlan.PRO,
+        currentPeriodEnd: input.currentPeriodEnd,
+        nextBillingAt: input.nextBillingAt,
+        paymentKind: 'INITIAL',
+      });
+    } catch (error) {
+      this.logger.warn(
+        `결제 성공 메일 발송에 실패했습니다. userId=${input.userId} error=${resolveErrorName(error)}`,
+      );
+    }
   }
 
   private canResumeWithoutImmediatePayment(subscription: {
@@ -156,4 +210,8 @@ export class ConfirmBillingAuthUseCase {
 
     return amount;
   }
+}
+
+function resolveErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : 'unknown';
 }

--- a/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
@@ -2,6 +2,7 @@
 import { ConfigService } from '@nestjs/config';
 import { ProcessDueAutoRenewalsUseCase } from './process-due-auto-renewals.usecase';
 import { BillingPaymentGateway } from '../ports/billing-payment.gateway';
+import { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
 import { SubscriptionsRepository } from '../../domain/subscriptions.repository';
 import {
   PaymentProvider,
@@ -13,6 +14,8 @@ import {
 
 const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
   getOrCreatePersonalSubscription: jest.fn(),
+  findBillingMailRecipientByUserId: jest.fn(),
+  findBillingMailRecipientBySubscriptionId: jest.fn(),
   updateSubscription: jest.fn(),
   activateByPayment: jest.fn(),
   recordPaymentFailure: jest.fn(),
@@ -23,6 +26,10 @@ const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
 const createGateway = (): jest.Mocked<BillingPaymentGateway> => ({
   issueBillingKey: jest.fn(),
   chargeBilling: jest.fn(),
+});
+
+const createMailer = (): jest.Mocked<SubscriptionPaymentMailPort> => ({
+  sendPaymentSuccess: jest.fn(),
 });
 
 const createConfig = () =>
@@ -67,9 +74,11 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
   it('배치 실행이 비활성화되어 있으면 due 구독 조회 전에 거부한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const usecase = new ProcessDueAutoRenewalsUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
 
@@ -89,9 +98,11 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
   it('배치 실행 시크릿이 설정되어 있지 않으면 due 구독 조회 전에 거부한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const usecase = new ProcessDueAutoRenewalsUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
 
@@ -111,9 +122,11 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
   it('요청 시크릿이 일치하지 않으면 due 구독 조회 전에 거부한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const usecase = new ProcessDueAutoRenewalsUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
 
@@ -133,6 +146,7 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
   it('자동결제 성공 시 기존 기간 뒤로 1개월 연장한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const now = new Date('2026-02-01T00:00:00.000Z');
 
     repo.findDueAutoRenewalSubscriptions.mockResolvedValue([
@@ -150,10 +164,20 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
       failureMessage: null,
       rawData: {},
     });
+    repo.activateByPayment.mockResolvedValue(
+      createSubscription({
+        currentPeriodEnd: new Date('2026-03-01T00:00:00.000Z'),
+        nextBillingAt: new Date('2026-03-01T00:00:00.000Z'),
+      }),
+    );
+    repo.findBillingMailRecipientBySubscriptionId.mockResolvedValue({
+      email: 'user@example.com',
+    });
 
     const usecase = new ProcessDueAutoRenewalsUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
     const result = await usecase.execute(createInput(now));
@@ -182,11 +206,22 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
       succeeded: 1,
       failed: 0,
     });
+    expect(mailer.sendPaymentSuccess).toHaveBeenCalledWith({
+      recipientEmail: 'user@example.com',
+      amount: 4900,
+      currency: 'KRW',
+      approvedAt: now,
+      plan: SubscriptionPlan.PRO,
+      currentPeriodEnd: new Date('2026-03-01T00:00:00.000Z'),
+      nextBillingAt: new Date('2026-03-01T00:00:00.000Z'),
+      paymentKind: 'AUTO_RENEWAL',
+    });
   });
 
   it('자동결제 실패 시 구독 기간을 변경하지 않고 실패 이력을 저장한다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const now = new Date('2026-02-01T00:00:00.000Z');
 
     repo.findDueAutoRenewalSubscriptions.mockResolvedValue([
@@ -208,6 +243,7 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
     const usecase = new ProcessDueAutoRenewalsUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
     const result = await usecase.execute(createInput(now));
@@ -220,6 +256,7 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
       }),
     );
     expect(repo.activateByPayment).not.toHaveBeenCalled();
+    expect(mailer.sendPaymentSuccess).not.toHaveBeenCalled();
     expect(result).toEqual({
       processed: 1,
       succeeded: 0,
@@ -230,6 +267,7 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
   it('동일 청구주기 결제가 이미 claim되어 있으면 외부 과금을 건너뛴다', async () => {
     const repo = createRepository();
     const gateway = createGateway();
+    const mailer = createMailer();
     const now = new Date('2026-02-01T00:00:00.000Z');
 
     repo.findDueAutoRenewalSubscriptions.mockResolvedValue([
@@ -240,6 +278,7 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
     const usecase = new ProcessDueAutoRenewalsUseCase(
       repo,
       gateway,
+      mailer,
       createConfig(),
     );
     const result = await usecase.execute(createInput(now));
@@ -254,9 +293,57 @@ describe('ProcessDueAutoRenewalsUseCase', () => {
     expect(gateway.chargeBilling).not.toHaveBeenCalled();
     expect(repo.activateByPayment).not.toHaveBeenCalled();
     expect(repo.recordPaymentFailure).not.toHaveBeenCalled();
+    expect(mailer.sendPaymentSuccess).not.toHaveBeenCalled();
     expect(result).toEqual({
       processed: 1,
       succeeded: 0,
+      failed: 0,
+    });
+  });
+
+  it('자동결제 성공 메일 발송 실패가 배치 성공 집계를 바꾸지 않는다', async () => {
+    const repo = createRepository();
+    const gateway = createGateway();
+    const mailer = createMailer();
+    const now = new Date('2026-02-01T00:00:00.000Z');
+
+    repo.findDueAutoRenewalSubscriptions.mockResolvedValue([
+      createSubscription(),
+    ]);
+    repo.claimAutoRenewalPayment.mockResolvedValue(true);
+    gateway.chargeBilling.mockResolvedValue({
+      paymentKey: 'payment-key',
+      orderId: 'provider-order-id',
+      status: SubscriptionPaymentStatus.DONE,
+      totalAmount: 4900,
+      currency: 'KRW',
+      approvedAt: now,
+      failureCode: null,
+      failureMessage: null,
+      rawData: {},
+    });
+    repo.activateByPayment.mockResolvedValue(
+      createSubscription({
+        currentPeriodEnd: new Date('2026-03-01T00:00:00.000Z'),
+        nextBillingAt: new Date('2026-03-01T00:00:00.000Z'),
+      }),
+    );
+    repo.findBillingMailRecipientBySubscriptionId.mockResolvedValue({
+      email: 'user@example.com',
+    });
+    mailer.sendPaymentSuccess.mockRejectedValue(new Error('resend failed'));
+
+    const usecase = new ProcessDueAutoRenewalsUseCase(
+      repo,
+      gateway,
+      mailer,
+      createConfig(),
+    );
+    const result = await usecase.execute(createInput(now));
+
+    expect(result).toEqual({
+      processed: 1,
+      succeeded: 1,
       failed: 0,
     });
   });

--- a/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
@@ -30,6 +30,7 @@ const createGateway = (): jest.Mocked<BillingPaymentGateway> => ({
 
 const createMailer = (): jest.Mocked<SubscriptionPaymentMailPort> => ({
   sendPaymentSuccess: jest.fn(),
+  sendSubscriptionResumed: jest.fn(),
 });
 
 const createConfig = () =>

--- a/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.ts
+++ b/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { timingSafeEqual } from 'crypto';
 import { SUBSCRIPTIONS_REPOSITORY } from '../../domain/subscriptions.repository';
@@ -6,9 +6,12 @@ import type { SubscriptionsRepository } from '../../domain/subscriptions.reposit
 import {
   PaymentProvider,
   SubscriptionPaymentStatus,
+  SubscriptionPlan,
 } from '../../domain/subscription.types';
 import { BILLING_PAYMENT_GATEWAY } from '../ports/billing-payment.gateway';
 import type { BillingPaymentGateway } from '../ports/billing-payment.gateway';
+import { SUBSCRIPTION_PAYMENT_MAIL_PORT } from '../ports/subscription-payment-mail.port';
+import type { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
 import { createAutoRenewalSubscriptionOrderId } from '../helpers/customer-key.helper';
 import { resolveNextPeriod } from '../helpers/subscription-period.helper';
 import { SubscriptionsError } from '../errors/subscriptions.error';
@@ -33,11 +36,15 @@ export type ProcessDueAutoRenewalsAccessPolicyInput = {
 
 @Injectable()
 export class ProcessDueAutoRenewalsUseCase {
+  private readonly logger = new Logger(ProcessDueAutoRenewalsUseCase.name);
+
   constructor(
     @Inject(SUBSCRIPTIONS_REPOSITORY)
     private readonly subscriptionsRepository: SubscriptionsRepository,
     @Inject(BILLING_PAYMENT_GATEWAY)
     private readonly billingPaymentGateway: BillingPaymentGateway,
+    @Inject(SUBSCRIPTION_PAYMENT_MAIL_PORT)
+    private readonly subscriptionPaymentMailPort: SubscriptionPaymentMailPort,
     private readonly configService: ConfigService,
   ) {}
 
@@ -105,7 +112,7 @@ export class ProcessDueAutoRenewalsUseCase {
         const paidAt = paymentResult.approvedAt ?? now;
         const period = resolveNextPeriod(subscription.currentPeriodEnd, paidAt);
 
-        await this.subscriptionsRepository.activateByPayment({
+        const updated = await this.subscriptionsRepository.activateByPayment({
           subscriptionId: subscription.id,
           provider: PaymentProvider.TOSS_PAYMENTS,
           status: SubscriptionPaymentStatus.DONE,
@@ -120,6 +127,14 @@ export class ProcessDueAutoRenewalsUseCase {
           currentPeriodEnd: period.currentPeriodEnd,
           nextBillingAt: period.nextBillingAt,
           rawData: paymentResult.rawData,
+        });
+        await this.sendPaymentSuccessMail({
+          subscriptionId: updated.id,
+          amount: paymentResult.totalAmount,
+          currency: paymentResult.currency,
+          approvedAt: paidAt,
+          currentPeriodEnd: period.currentPeriodEnd,
+          nextBillingAt: period.nextBillingAt,
         });
         succeeded += 1;
         continue;
@@ -152,6 +167,45 @@ export class ProcessDueAutoRenewalsUseCase {
     const raw = this.configService.get<string>('PRO_MONTHLY_AMOUNT');
     const amount = raw ? Number(raw) : 4900;
     return Number.isInteger(amount) && amount > 0 ? amount : 4900;
+  }
+
+  private async sendPaymentSuccessMail(input: {
+    subscriptionId: string;
+    amount: number;
+    currency: string;
+    approvedAt: Date;
+    currentPeriodEnd: Date;
+    nextBillingAt: Date;
+  }): Promise<void> {
+    try {
+      const recipient =
+        await this.subscriptionsRepository.findBillingMailRecipientBySubscriptionId(
+          input.subscriptionId,
+        );
+
+      if (!recipient) {
+        this.logger.warn(
+          `자동결제 성공 메일 수신자를 찾지 못했습니다. subscriptionId=${input.subscriptionId}`,
+        );
+        return;
+      }
+
+      // 자동결제 배치의 성공/실패 집계는 결제 결과 기준이며, 메일 발송 실패로 성공 건을 실패 처리하지 않는다.
+      await this.subscriptionPaymentMailPort.sendPaymentSuccess({
+        recipientEmail: recipient.email,
+        amount: input.amount,
+        currency: input.currency,
+        approvedAt: input.approvedAt,
+        plan: SubscriptionPlan.PRO,
+        currentPeriodEnd: input.currentPeriodEnd,
+        nextBillingAt: input.nextBillingAt,
+        paymentKind: 'AUTO_RENEWAL',
+      });
+    } catch (error) {
+      this.logger.warn(
+        `자동결제 성공 메일 발송에 실패했습니다. subscriptionId=${input.subscriptionId} error=${resolveErrorName(error)}`,
+      );
+    }
   }
 
   private assertAutoRenewalsBatchAllowed(
@@ -190,4 +244,8 @@ function isSameSecret(providedSecret: string, expectedSecret: string): boolean {
   return (
     provided.length === expected.length && timingSafeEqual(provided, expected)
   );
+}
+
+function resolveErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : 'unknown';
 }

--- a/src/subscriptions/application/usecases/update-my-subscription.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/update-my-subscription.usecase.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { UpdateMySubscriptionUseCase } from './update-my-subscription.usecase';
+import { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
 import { SubscriptionsRepository } from '../../domain/subscriptions.repository';
 import {
   PaymentProvider,
@@ -11,11 +12,18 @@ import {
 
 const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
   getOrCreatePersonalSubscription: jest.fn(),
+  findBillingMailRecipientByUserId: jest.fn(),
+  findBillingMailRecipientBySubscriptionId: jest.fn(),
   updateSubscription: jest.fn(),
   activateByPayment: jest.fn(),
   recordPaymentFailure: jest.fn(),
   claimAutoRenewalPayment: jest.fn(),
   findDueAutoRenewalSubscriptions: jest.fn(),
+});
+
+const createMailer = (): jest.Mocked<SubscriptionPaymentMailPort> => ({
+  sendPaymentSuccess: jest.fn(),
+  sendSubscriptionResumed: jest.fn(),
 });
 
 const createSubscription = (
@@ -62,7 +70,7 @@ describe('UpdateMySubscriptionUseCase', () => {
       }),
     );
 
-    const usecase = new UpdateMySubscriptionUseCase(repo);
+    const usecase = new UpdateMySubscriptionUseCase(repo, createMailer());
     const result = await usecase.execute('user-id', {
       type: SubscriptionAction.CANCEL,
     });
@@ -82,6 +90,7 @@ describe('UpdateMySubscriptionUseCase', () => {
 
   it('빌링키가 있는 해지 구독은 자동갱신을 재개할 수 있다', async () => {
     const repo = createRepository();
+    const mailer = createMailer();
     const currentPeriodEnd = new Date('2099-03-01T00:00:00.000Z');
 
     repo.getOrCreatePersonalSubscription.mockResolvedValue(
@@ -104,8 +113,11 @@ describe('UpdateMySubscriptionUseCase', () => {
         nextBillingAt: currentPeriodEnd,
       }),
     );
+    repo.findBillingMailRecipientByUserId.mockResolvedValue({
+      email: 'user@example.com',
+    });
 
-    const usecase = new UpdateMySubscriptionUseCase(repo);
+    const usecase = new UpdateMySubscriptionUseCase(repo, mailer);
     await usecase.execute('user-id', {
       type: SubscriptionAction.RESUME,
     });
@@ -115,6 +127,57 @@ describe('UpdateMySubscriptionUseCase', () => {
       autoRenew: true,
       nextBillingAt: currentPeriodEnd,
     });
+    expect(mailer.sendSubscriptionResumed).toHaveBeenCalledWith({
+      recipientEmail: 'user@example.com',
+      plan: SubscriptionPlan.PRO,
+      currentPeriodEnd,
+      nextBillingAt: currentPeriodEnd,
+    });
+  });
+
+  it('구독 재개 메일 발송 실패가 재개 응답을 막지 않는다', async () => {
+    const repo = createRepository();
+    const mailer = createMailer();
+    const currentPeriodEnd = new Date('2099-03-01T00:00:00.000Z');
+
+    repo.getOrCreatePersonalSubscription.mockResolvedValue(
+      createSubscription({
+        plan: SubscriptionPlan.PRO,
+        status: SubscriptionStatus.CANCELED,
+        autoRenew: false,
+        currentPeriodEnd,
+        provider: PaymentProvider.TOSS_PAYMENTS,
+        externalBillingKey: 'billing-key',
+        externalCustomerKey: 'customer-key',
+      }),
+    );
+    repo.updateSubscription.mockResolvedValue(
+      createSubscription({
+        plan: SubscriptionPlan.PRO,
+        status: SubscriptionStatus.ACTIVE,
+        autoRenew: true,
+        currentPeriodEnd,
+        nextBillingAt: currentPeriodEnd,
+      }),
+    );
+    repo.findBillingMailRecipientByUserId.mockResolvedValue({
+      email: 'user@example.com',
+    });
+    mailer.sendSubscriptionResumed.mockRejectedValue(
+      new Error('resend failed'),
+    );
+
+    const usecase = new UpdateMySubscriptionUseCase(repo, mailer);
+
+    await expect(
+      usecase.execute('user-id', {
+        type: SubscriptionAction.RESUME,
+      }),
+    ).resolves.toMatchObject({
+      plan: SubscriptionPlan.PRO,
+      status: SubscriptionStatus.ACTIVE,
+      autoRenew: true,
+    });
   });
 
   it('FREE 상태에서 해지를 요청하면 CONFLICT를 반환한다', async () => {
@@ -123,7 +186,7 @@ describe('UpdateMySubscriptionUseCase', () => {
       createSubscription(),
     );
 
-    const usecase = new UpdateMySubscriptionUseCase(repo);
+    const usecase = new UpdateMySubscriptionUseCase(repo, createMailer());
 
     await expect(
       usecase.execute('user-id', {

--- a/src/subscriptions/application/usecases/update-my-subscription.usecase.ts
+++ b/src/subscriptions/application/usecases/update-my-subscription.usecase.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SUBSCRIPTIONS_REPOSITORY } from '../../domain/subscriptions.repository';
 import type { SubscriptionsRepository } from '../../domain/subscriptions.repository';
 import {
@@ -7,6 +7,8 @@ import {
   SubscriptionPlan,
   SubscriptionStatus,
 } from '../../domain/subscription.types';
+import { SUBSCRIPTION_PAYMENT_MAIL_PORT } from '../ports/subscription-payment-mail.port';
+import type { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
 import { MySubscriptionOutput } from '../dtos/my-subscription-output.dto';
 import { UpdateMySubscriptionInput } from '../dtos/update-my-subscription-input.dto';
 import { SubscriptionsError } from '../errors/subscriptions.error';
@@ -15,9 +17,13 @@ import { toMySubscriptionResponse } from '../helpers/subscription-response.helpe
 
 @Injectable()
 export class UpdateMySubscriptionUseCase {
+  private readonly logger = new Logger(UpdateMySubscriptionUseCase.name);
+
   constructor(
     @Inject(SUBSCRIPTIONS_REPOSITORY)
     private readonly subscriptionsRepository: SubscriptionsRepository,
+    @Inject(SUBSCRIPTION_PAYMENT_MAIL_PORT)
+    private readonly subscriptionPaymentMailPort: SubscriptionPaymentMailPort,
   ) {}
 
   async execute(
@@ -38,7 +44,10 @@ export class UpdateMySubscriptionUseCase {
     }
 
     if (input.type === SubscriptionAction.RESUME) {
-      return toMySubscriptionResponse(await this.resume(subscription));
+      const updated = await this.resume(subscription);
+      await this.sendSubscriptionResumedMail(userId, updated);
+
+      return toMySubscriptionResponse(updated);
     }
 
     throw new SubscriptionsError(
@@ -84,4 +93,43 @@ export class UpdateMySubscriptionUseCase {
       nextBillingAt: subscription.currentPeriodEnd,
     });
   }
+
+  private async sendSubscriptionResumedMail(
+    userId: string,
+    subscription: Subscription,
+  ): Promise<void> {
+    if (!subscription.currentPeriodEnd || !subscription.nextBillingAt) {
+      return;
+    }
+
+    try {
+      const recipient =
+        await this.subscriptionsRepository.findBillingMailRecipientByUserId(
+          userId,
+        );
+
+      if (!recipient) {
+        this.logger.warn(
+          `구독 재개 메일 수신자를 찾지 못했습니다. userId=${userId}`,
+        );
+        return;
+      }
+
+      // 재개는 즉시 과금이 아니므로 결제 성공 메일과 분리해 다음 결제 예정일만 안내한다.
+      await this.subscriptionPaymentMailPort.sendSubscriptionResumed({
+        recipientEmail: recipient.email,
+        plan: SubscriptionPlan.PRO,
+        currentPeriodEnd: subscription.currentPeriodEnd,
+        nextBillingAt: subscription.nextBillingAt,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `구독 재개 메일 발송에 실패했습니다. userId=${userId} error=${resolveErrorName(error)}`,
+      );
+    }
+  }
+}
+
+function resolveErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : 'unknown';
 }

--- a/src/subscriptions/domain/subscriptions.repository.ts
+++ b/src/subscriptions/domain/subscriptions.repository.ts
@@ -54,8 +54,20 @@ export type ClaimAutoRenewalPaymentParams = {
   currency: string;
 };
 
+export type BillingMailRecipient = {
+  email: string;
+};
+
 export interface SubscriptionsRepository {
   getOrCreatePersonalSubscription(userId: string): Promise<Subscription>;
+
+  findBillingMailRecipientByUserId(
+    userId: string,
+  ): Promise<BillingMailRecipient | null>;
+
+  findBillingMailRecipientBySubscriptionId(
+    subscriptionId: string,
+  ): Promise<BillingMailRecipient | null>;
 
   updateSubscription(
     subscriptionId: string,

--- a/src/subscriptions/infrastructure/prisma-subscriptions.repository.ts
+++ b/src/subscriptions/infrastructure/prisma-subscriptions.repository.ts
@@ -9,6 +9,7 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
   ActivateSubscriptionPaymentParams,
+  BillingMailRecipient,
   ClaimAutoRenewalPaymentParams,
   MarkPaymentFailedParams,
   SubscriptionsRepository,
@@ -69,6 +70,37 @@ export class PrismaSubscriptionsRepository implements SubscriptionsRepository {
         select: subscriptionSelect,
       });
     });
+  }
+
+  async findBillingMailRecipientByUserId(
+    userId: string,
+  ): Promise<BillingMailRecipient | null> {
+    return this.findBillingMailRecipientByOwnerUserId(userId);
+  }
+
+  async findBillingMailRecipientBySubscriptionId(
+    subscriptionId: string,
+  ): Promise<BillingMailRecipient | null> {
+    const subscription = await this.prisma.subscription.findUnique({
+      where: {
+        id: subscriptionId,
+      },
+      select: {
+        workspace: {
+          select: {
+            ownerUserId: true,
+          },
+        },
+      },
+    });
+
+    if (!subscription) {
+      return null;
+    }
+
+    return this.findBillingMailRecipientByOwnerUserId(
+      subscription.workspace.ownerUserId,
+    );
   }
 
   async updateSubscription(
@@ -184,6 +216,28 @@ export class PrismaSubscriptionsRepository implements SubscriptionsRepository {
       take: limit,
       select: subscriptionSelect,
     });
+  }
+
+  private async findBillingMailRecipientByOwnerUserId(
+    userId: string,
+  ): Promise<BillingMailRecipient | null> {
+    const account = await this.prisma.authAccount.findFirst({
+      where: {
+        userId,
+        email: {
+          not: '',
+        },
+      },
+      // AuthAccount에는 primary 플래그가 없으므로 id 기준으로 고정해 대표 이메일 선택을 재현 가능하게 만든다.
+      orderBy: {
+        id: 'asc',
+      },
+      select: {
+        email: true,
+      },
+    });
+
+    return account ? { email: account.email } : null;
   }
 
   private toSubscriptionUpdateData(

--- a/src/subscriptions/infrastructure/resend-subscription-payment-mail.service.ts
+++ b/src/subscriptions/infrastructure/resend-subscription-payment-mail.service.ts
@@ -1,0 +1,193 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Resend } from 'resend';
+import {
+  SendSubscriptionPaymentSuccessMailInput,
+  SubscriptionPaymentMailPort,
+} from '../application/ports/subscription-payment-mail.port';
+
+const DEFAULT_SUPPORT_EMAIL = 'support@easy-clip.app';
+
+@Injectable()
+export class ResendSubscriptionPaymentMailService implements SubscriptionPaymentMailPort {
+  private client: Resend | null = null;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async sendPaymentSuccess(
+    input: SendSubscriptionPaymentSuccessMailInput,
+  ): Promise<void> {
+    if (!this.isMailEnabled()) {
+      return;
+    }
+
+    const response = await this.getClient().emails.send({
+      from: this.getRequired('MAIL_FROM_ADDRESS'),
+      to: input.recipientEmail,
+      subject: this.buildSubject(input),
+      text: this.buildText(input),
+      html: this.buildHtml(input),
+      tags: [
+        {
+          name: 'category',
+          value: 'subscription-payment-success',
+        },
+        {
+          name: 'payment_kind',
+          value: input.paymentKind.toLowerCase(),
+        },
+      ],
+    });
+
+    if (response.error) {
+      throw new Error(
+        `Resend payment success mail failed: ${response.error.name}(${response.error.statusCode})`,
+      );
+    }
+  }
+
+  private isMailEnabled(): boolean {
+    // 실제 메일 발송은 side effect가 크므로 환경변수로 명시적으로 켠 경우에만 수행한다.
+    return this.configService.get<string>('MAIL_ENABLED') === 'true';
+  }
+
+  private getClient(): Resend {
+    if (!this.client) {
+      this.client = new Resend(this.getRequired('RESEND_API_KEY'));
+    }
+
+    return this.client;
+  }
+
+  private getRequired(key: string): string {
+    const value = this.configService.get<string>(key)?.trim();
+
+    if (!value) {
+      throw new Error(`${key} 환경 변수가 필요합니다.`);
+    }
+
+    return value;
+  }
+
+  private buildSubject(input: SendSubscriptionPaymentSuccessMailInput): string {
+    return input.paymentKind === 'INITIAL'
+      ? 'Easy Clip PRO 구독 결제가 완료되었습니다'
+      : 'Easy Clip PRO 구독 자동결제가 완료되었습니다';
+  }
+
+  private buildText(input: SendSubscriptionPaymentSuccessMailInput): string {
+    const supportEmail =
+      this.configService.get<string>('MAIL_SUPPORT_EMAIL') ??
+      DEFAULT_SUPPORT_EMAIL;
+
+    return [
+      '안녕하세요. Easy Clip입니다.',
+      '',
+      `${this.resolvePaymentLabel(input)}가 정상적으로 완료되었습니다.`,
+      '',
+      `구독 플랜: ${input.plan}`,
+      `결제 금액: ${this.formatAmount(input.amount, input.currency)}`,
+      `승인 시각: ${this.formatDateTime(input.approvedAt)}`,
+      `현재 이용 기간 종료일: ${this.formatDate(input.currentPeriodEnd)}`,
+      `다음 결제 예정일: ${this.formatDate(input.nextBillingAt)}`,
+      '',
+      `문의가 필요하시면 ${supportEmail}로 연락해주세요.`,
+      '',
+      'Easy Clip 드림',
+    ].join('\n');
+  }
+
+  private buildHtml(input: SendSubscriptionPaymentSuccessMailInput): string {
+    const supportEmail = escapeHtml(
+      this.configService.get<string>('MAIL_SUPPORT_EMAIL') ??
+        DEFAULT_SUPPORT_EMAIL,
+    );
+    const title = escapeHtml(this.resolvePaymentLabel(input));
+
+    return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  </head>
+  <body style="margin:0;background-color:#f6f8fb;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f6f8fb" style="width:100%;background-color:#f6f8fb;">
+      <tr>
+        <td align="center" style="padding-top:32px;padding-right:16px;padding-bottom:32px;padding-left:16px;">
+          <table width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;background-color:#ffffff;border:1px solid #e5e7eb;">
+            <tr>
+              <td style="padding-top:28px;padding-right:28px;padding-bottom:12px;padding-left:28px;">
+                <p style="margin:0;font-size:14px;line-height:20px;color:#4b5563;">Easy Clip</p>
+                <h1 style="margin-top:8px;margin-right:0;margin-bottom:0;margin-left:0;font-size:24px;line-height:32px;color:#111827;font-weight:700;">${title}가 완료되었습니다</h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding-top:8px;padding-right:28px;padding-bottom:28px;padding-left:28px;">
+                ${this.buildHtmlRow('구독 플랜', input.plan)}
+                ${this.buildHtmlRow('결제 금액', this.formatAmount(input.amount, input.currency))}
+                ${this.buildHtmlRow('승인 시각', this.formatDateTime(input.approvedAt))}
+                ${this.buildHtmlRow('현재 이용 기간 종료일', this.formatDate(input.currentPeriodEnd))}
+                ${this.buildHtmlRow('다음 결제 예정일', this.formatDate(input.nextBillingAt))}
+              </td>
+            </tr>
+            <tr>
+              <td bgcolor="#f9fafb" style="padding-top:18px;padding-right:28px;padding-bottom:18px;padding-left:28px;background-color:#f9fafb;border-top:1px solid #e5e7eb;">
+                <p style="margin:0;font-size:13px;line-height:20px;color:#4b5563;">문의가 필요하시면 ${supportEmail}로 연락해주세요.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+  }
+
+  private buildHtmlRow(label: string, value: string): string {
+    return `<table width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;border-bottom:1px solid #eef2f7;">
+  <tr>
+    <td style="padding-top:12px;padding-right:12px;padding-bottom:12px;padding-left:0;font-size:14px;line-height:20px;color:#6b7280;">${escapeHtml(label)}</td>
+    <td align="right" style="padding-top:12px;padding-right:0;padding-bottom:12px;padding-left:12px;font-size:14px;line-height:20px;color:#111827;font-weight:600;">${escapeHtml(value)}</td>
+  </tr>
+</table>`;
+  }
+
+  private resolvePaymentLabel(
+    input: SendSubscriptionPaymentSuccessMailInput,
+  ): string {
+    return input.paymentKind === 'INITIAL' ? '구독 결제' : '구독 자동결제';
+  }
+
+  private formatAmount(amount: number, currency: string): string {
+    if (currency === 'KRW') {
+      return `${amount.toLocaleString('ko-KR')}원`;
+    }
+
+    return `${amount.toLocaleString('ko-KR')} ${currency}`;
+  }
+
+  private formatDate(value: Date): string {
+    return new Intl.DateTimeFormat('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      dateStyle: 'medium',
+    }).format(value);
+  }
+
+  private formatDateTime(value: Date): string {
+    return new Intl.DateTimeFormat('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(value);
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/src/subscriptions/infrastructure/resend-subscription-payment-mail.service.ts
+++ b/src/subscriptions/infrastructure/resend-subscription-payment-mail.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Resend } from 'resend';
 import {
   SendSubscriptionPaymentSuccessMailInput,
+  SendSubscriptionResumedMailInput,
   SubscriptionPaymentMailPort,
 } from '../application/ports/subscription-payment-mail.port';
 
@@ -42,6 +43,34 @@ export class ResendSubscriptionPaymentMailService implements SubscriptionPayment
     if (response.error) {
       throw new Error(
         `Resend payment success mail failed: ${response.error.name}(${response.error.statusCode})`,
+      );
+    }
+  }
+
+  async sendSubscriptionResumed(
+    input: SendSubscriptionResumedMailInput,
+  ): Promise<void> {
+    if (!this.isMailEnabled()) {
+      return;
+    }
+
+    const response = await this.getClient().emails.send({
+      from: this.getRequired('MAIL_FROM_ADDRESS'),
+      to: input.recipientEmail,
+      subject: 'Easy Clip PRO 구독 자동갱신이 재개되었습니다',
+      text: this.buildResumeText(input),
+      html: this.buildResumeHtml(input),
+      tags: [
+        {
+          name: 'category',
+          value: 'subscription-resumed',
+        },
+      ],
+    });
+
+    if (response.error) {
+      throw new Error(
+        `Resend subscription resumed mail failed: ${response.error.name}(${response.error.statusCode})`,
       );
     }
   }
@@ -129,6 +158,77 @@ export class ResendSubscriptionPaymentMailService implements SubscriptionPayment
                 ${this.buildHtmlRow('승인 시각', this.formatDateTime(input.approvedAt))}
                 ${this.buildHtmlRow('현재 이용 기간 종료일', this.formatDate(input.currentPeriodEnd))}
                 ${this.buildHtmlRow('다음 결제 예정일', this.formatDate(input.nextBillingAt))}
+              </td>
+            </tr>
+            <tr>
+              <td bgcolor="#f9fafb" style="padding-top:18px;padding-right:28px;padding-bottom:18px;padding-left:28px;background-color:#f9fafb;border-top:1px solid #e5e7eb;">
+                <p style="margin:0;font-size:13px;line-height:20px;color:#4b5563;">문의가 필요하시면 ${supportEmail}로 연락해주세요.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+  }
+
+  private buildResumeText(input: SendSubscriptionResumedMailInput): string {
+    const supportEmail =
+      this.configService.get<string>('MAIL_SUPPORT_EMAIL') ??
+      DEFAULT_SUPPORT_EMAIL;
+
+    return [
+      '안녕하세요. Easy Clip입니다.',
+      '',
+      'Easy Clip PRO 구독 자동갱신이 재개되었습니다.',
+      '',
+      `구독 플랜: ${input.plan}`,
+      `현재 이용 기간 종료일: ${this.formatDate(input.currentPeriodEnd)}`,
+      `다음 결제 예정일: ${this.formatDate(input.nextBillingAt)}`,
+      '',
+      '재개 시점에는 즉시 결제가 발생하지 않으며, 다음 결제 예정일에 자동결제가 진행됩니다.',
+      '',
+      `문의가 필요하시면 ${supportEmail}로 연락해주세요.`,
+      '',
+      'Easy Clip 드림',
+    ].join('\n');
+  }
+
+  private buildResumeHtml(input: SendSubscriptionResumedMailInput): string {
+    const supportEmail = escapeHtml(
+      this.configService.get<string>('MAIL_SUPPORT_EMAIL') ??
+        DEFAULT_SUPPORT_EMAIL,
+    );
+
+    return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  </head>
+  <body style="margin:0;background-color:#f6f8fb;font-family:Arial,Helvetica,sans-serif;color:#1f2937;">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f6f8fb" style="width:100%;background-color:#f6f8fb;">
+      <tr>
+        <td align="center" style="padding-top:32px;padding-right:16px;padding-bottom:32px;padding-left:16px;">
+          <table width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;background-color:#ffffff;border:1px solid #e5e7eb;">
+            <tr>
+              <td style="padding-top:28px;padding-right:28px;padding-bottom:12px;padding-left:28px;">
+                <p style="margin:0;font-size:14px;line-height:20px;color:#4b5563;">Easy Clip</p>
+                <h1 style="margin-top:8px;margin-right:0;margin-bottom:0;margin-left:0;font-size:24px;line-height:32px;color:#111827;font-weight:700;">PRO 구독 자동갱신이 재개되었습니다</h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding-top:8px;padding-right:28px;padding-bottom:12px;padding-left:28px;">
+                ${this.buildHtmlRow('구독 플랜', input.plan)}
+                ${this.buildHtmlRow('현재 이용 기간 종료일', this.formatDate(input.currentPeriodEnd))}
+                ${this.buildHtmlRow('다음 결제 예정일', this.formatDate(input.nextBillingAt))}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding-top:0;padding-right:28px;padding-bottom:28px;padding-left:28px;">
+                <p style="margin:0;font-size:14px;line-height:22px;color:#374151;">재개 시점에는 즉시 결제가 발생하지 않으며, 다음 결제 예정일에 자동결제가 진행됩니다.</p>
               </td>
             </tr>
             <tr>

--- a/src/subscriptions/subscriptions.module.ts
+++ b/src/subscriptions/subscriptions.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { JwtAccessGuard } from 'src/shared/presentation/guards/jwt-access.guard';
 import { SUBSCRIPTIONS_REPOSITORY } from './domain/subscriptions.repository';
 import { BILLING_PAYMENT_GATEWAY } from './application/ports/billing-payment.gateway';
+import { SUBSCRIPTION_PAYMENT_MAIL_PORT } from './application/ports/subscription-payment-mail.port';
 import { ConfirmBillingAuthUseCase } from './application/usecases/confirm-billing-auth.usecase';
 import { CreateBillingAuthRequestUseCase } from './application/usecases/create-billing-auth-request.usecase';
 import { GetMySubscriptionUseCase } from './application/usecases/get-my-subscription.usecase';
 import { ProcessDueAutoRenewalsUseCase } from './application/usecases/process-due-auto-renewals.usecase';
 import { UpdateMySubscriptionUseCase } from './application/usecases/update-my-subscription.usecase';
 import { PrismaSubscriptionsRepository } from './infrastructure/prisma-subscriptions.repository';
+import { ResendSubscriptionPaymentMailService } from './infrastructure/resend-subscription-payment-mail.service';
 import { TossPaymentsBillingGateway } from './infrastructure/toss-payments-billing.gateway';
 import { SubscriptionsController } from './presentation/subscriptions.controller';
 
@@ -21,6 +23,10 @@ import { SubscriptionsController } from './presentation/subscriptions.controller
     {
       provide: BILLING_PAYMENT_GATEWAY,
       useClass: TossPaymentsBillingGateway,
+    },
+    {
+      provide: SUBSCRIPTION_PAYMENT_MAIL_PORT,
+      useClass: ResendSubscriptionPaymentMailService,
     },
     GetMySubscriptionUseCase,
     UpdateMySubscriptionUseCase,


### PR DESCRIPTION
## Description

결제 성공 메일 발송 기능을 Resend SDK 기반으로 구현했습니다.

최초 결제 성공, 자동갱신 결제 성공, 구독 재개 알림 메일을 발송하며, 메일 발송 실패가 결제 성공 처리나 구독 재개 응답을 막지 않도록 best-effort로 처리합니다.

## Type of change

- 신규 기능 (호환성에 영향을 주지 않는 기능 추가)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #116

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- `subscriptions` 기능 도메인의 application 레이어에 메일 발송 포트를 추가했습니다.
- Resend SDK를 사용하는 메일 발송 구현체를 infrastructure 레이어에 추가했습니다.
- 최초 결제 성공과 자동갱신 결제 성공 후 결제 성공 메일을 발송합니다.
- 구독 재개 시 즉시 과금이 없다는 점과 다음 결제 예정일을 안내하는 재개 알림 메일을 발송합니다.
- GitHub 로그인 사용자의 수신 이메일 정확도를 위해 GitHub 이메일 API에서 primary verified 이메일을 우선 선택하도록 보강했습니다.
- Resend API Key와 발신자 주소는 환경변수로 관리하며, 운영 예시 파일에 placeholder를 추가했습니다.
- 실제 메일 발송은 `MAIL_ENABLED=true`일 때만 수행합니다.

## Performance/Scaling

- 메일 발송은 결제/재개 성공 이후 best-effort로 수행합니다.
- 메일 발송 실패는 warning 로그만 남기며 결제 성공 처리, 자동갱신 성공 집계, 구독 재개 응답을 롤백하지 않습니다.

## Testing done

- `pnpm test`
- `pnpm lint`
- `pnpm build`

## Additional information

- Resend MCP로 `easy-clip.app` 도메인이 verified 및 sending enabled 상태임을 확인했습니다.
- Resend MCP 조회 결과 최근 트랜잭션 이메일은 없었고, 실제 테스트 메일 발송은 수행하지 않았습니다.
