### PR TITLE
#120/fix(user) : 일본어·중국어 언어 설정 저장 허용

### DIFF
--- a/src/users/application/dtos/update-user-settings-input.dto.ts
+++ b/src/users/application/dtos/update-user-settings-input.dto.ts
@@ -1,6 +1,6 @@
-import type { UserTheme } from '../../domain/user.types';
+import type { UserLanguage, UserTheme } from '../../domain/user.types';
 
 export type UpdateUserSettingsInput = {
   theme?: UserTheme;
-  language?: string;
+  language?: UserLanguage;
 };

--- a/src/users/application/dtos/user-settings-output.dto.ts
+++ b/src/users/application/dtos/user-settings-output.dto.ts
@@ -1,8 +1,8 @@
-import type { UserTheme } from '../../domain/user.types';
+import type { UserLanguage, UserTheme } from '../../domain/user.types';
 
 export type UserSettingsOutput = {
   id: string;
   userId: string;
   theme: UserTheme;
-  language: string;
+  language: UserLanguage;
 };

--- a/src/users/application/usecases/update-user-settings.usecase.spec.ts
+++ b/src/users/application/usecases/update-user-settings.usecase.spec.ts
@@ -22,6 +22,33 @@ describe('UpdateUserSettingsUseCase', () => {
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
+  it.each(['ja', 'zh'] as const)(
+    '%s language를 부분 수정한다',
+    async (language) => {
+      const repo = createRepository();
+      repo.findUserById.mockResolvedValue({ id: 'user-id' });
+      repo.upsertUserSettings.mockResolvedValue({
+        id: 'settings-id',
+        userId: 'user-id',
+        theme: 'DARK',
+        language,
+      });
+
+      const usecase = new UpdateUserSettingsUseCase(repo);
+      const result = await usecase.execute('user-id', {
+        theme: 'DARK',
+        language,
+      });
+
+      expect(repo.upsertUserSettings).toHaveBeenCalledWith('user-id', {
+        theme: 'DARK',
+        language,
+      });
+      expect(result.theme).toBe('DARK');
+      expect(result.language).toBe(language);
+    },
+  );
+
   it('theme/language를 부분 수정한다', async () => {
     const repo = createRepository();
     repo.findUserById.mockResolvedValue({ id: 'user-id' });

--- a/src/users/domain/user.types.ts
+++ b/src/users/domain/user.types.ts
@@ -3,6 +3,9 @@ import type { AuthProvider } from 'src/shared/types/auth-provider.type';
 export const USER_THEMES = ['LIGHT', 'DARK', 'SYSTEM'] as const;
 export type UserTheme = (typeof USER_THEMES)[number];
 
+export const USER_LANGUAGES = ['ko', 'en', 'ja', 'zh'] as const;
+export type UserLanguage = (typeof USER_LANGUAGES)[number];
+
 export type UserSummary = {
   id: string;
 };
@@ -35,5 +38,5 @@ export type UserSettings = {
   id: string;
   userId: string;
   theme: UserTheme;
-  language: string;
+  language: UserLanguage;
 };

--- a/src/users/domain/users.repository.ts
+++ b/src/users/domain/users.repository.ts
@@ -1,5 +1,6 @@
 import {
   UserAuthAccount,
+  UserLanguage,
   UserSettings,
   UserSummary,
   UserTheme,
@@ -15,7 +16,7 @@ export type UpdateAuthAccountProfileParams = {
 
 export type UpdateUserSettingsParams = {
   theme?: UserTheme;
-  language?: string;
+  language?: UserLanguage;
 };
 
 export interface UsersRepository {

--- a/src/users/infrastructure/prisma-users.repository.ts
+++ b/src/users/infrastructure/prisma-users.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import type { UserSettings as PrismaUserSettings } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
   UpdateAuthAccountProfileParams,
@@ -7,6 +8,7 @@ import {
 } from '../domain/users.repository';
 import {
   UserAuthAccount,
+  UserLanguage,
   UserSettings,
   UserSummary,
   UserWithAuthAccounts,
@@ -75,7 +77,7 @@ export class PrismaUsersRepository implements UsersRepository {
     userId: string,
     params: UpdateUserSettingsParams,
   ): Promise<UserSettings> {
-    return this.prisma.userSettings.upsert({
+    const settings = await this.prisma.userSettings.upsert({
       where: { userId },
       create: {
         userId,
@@ -87,6 +89,8 @@ export class PrismaUsersRepository implements UsersRepository {
         ...(params.language !== undefined ? { language: params.language } : {}),
       },
     });
+
+    return this.toUserSettings(settings);
   }
 
   async deleteUserAndOwnedPersonalWorkspaces(userId: string): Promise<void> {
@@ -120,5 +124,12 @@ export class PrismaUsersRepository implements UsersRepository {
         where: { id: userId },
       });
     });
+  }
+
+  private toUserSettings(settings: PrismaUserSettings): UserSettings {
+    return {
+      ...settings,
+      language: settings.language as UserLanguage,
+    };
   }
 }

--- a/src/users/presentation/dtos/update-user-settings.dto.ts
+++ b/src/users/presentation/dtos/update-user-settings.dto.ts
@@ -1,6 +1,11 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional } from 'class-validator';
-import { USER_THEMES, type UserTheme } from '../../domain/user.types';
+import {
+  USER_LANGUAGES,
+  USER_THEMES,
+  type UserLanguage,
+  type UserTheme,
+} from '../../domain/user.types';
 
 export class UpdateUserSettingsDto {
   @ApiPropertyOptional({ enum: USER_THEMES, example: 'SYSTEM' })
@@ -8,8 +13,8 @@ export class UpdateUserSettingsDto {
   @IsIn(USER_THEMES)
   theme?: UserTheme;
 
-  @ApiPropertyOptional({ enum: ['ko', 'en'], example: 'ko' })
+  @ApiPropertyOptional({ enum: USER_LANGUAGES, example: 'ko' })
   @IsOptional()
-  @IsIn(['ko', 'en'])
-  language?: 'ko' | 'en';
+  @IsIn(USER_LANGUAGES)
+  language?: UserLanguage;
 }

--- a/src/users/presentation/dtos/user-response.dto.ts
+++ b/src/users/presentation/dtos/user-response.dto.ts
@@ -1,4 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
+import {
+  USER_LANGUAGES,
+  USER_THEMES,
+  type UserLanguage,
+  type UserTheme,
+} from '../../domain/user.types';
 
 export class UserAuthAccountResponseDto {
   @ApiProperty({ example: 'cmauth123' })
@@ -35,11 +41,11 @@ export class UserSettingsResponseDto {
   @ApiProperty({ example: 'cmuser123' })
   userId: string;
 
-  @ApiProperty({ enum: ['LIGHT', 'DARK', 'SYSTEM'], example: 'SYSTEM' })
-  theme: 'LIGHT' | 'DARK' | 'SYSTEM';
+  @ApiProperty({ enum: USER_THEMES, example: 'SYSTEM' })
+  theme: UserTheme;
 
-  @ApiProperty({ example: 'ko' })
-  language: string;
+  @ApiProperty({ enum: USER_LANGUAGES, example: 'ko' })
+  language: UserLanguage;
 }
 
 export class DeleteMeResponseDto {


### PR DESCRIPTION
## Description

사용자 설정 수정 API에서 언어 값을 저장할 때 일본어(`ja`)와 중국어(`zh`)가 정상적으로 허용되도록 타입, DTO, Prisma 저장 로직을 정리했습니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #120

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- 사용자 설정 언어 타입과 입출력 DTO에서 `ja`, `zh`를 허용하도록 확장했습니다.
- Prisma 사용자 설정 저장 로직에서 새 언어 코드를 처리하도록 반영했습니다.
- `UpdateUserSettingsUseCase` 테스트에 일본어·중국어 저장 케이스를 추가했습니다.

## Performance/Scaling

- N/A

## Testing done

- `pnpm lint`: 통과
- `pnpm test`: 통과 (50개 테스트 스위트, 212개 테스트)
- `pnpm test:e2e`: 미실행 (유스케이스/DTO 범위 변경으로 해당 없음)

## Additional information

- `gh` CLI 토큰은 만료되어 있었지만, GitHub 커넥터로 PR을 생성했습니다.