### PR TITLE
#125/fix(setting) : 테마 설정 옵션을 라이트와 다크로 제한

### DIFF
--- a/prisma/migrations/20260715000000_limit_theme_to_light_dark/migration.sql
+++ b/prisma/migrations/20260715000000_limit_theme_to_light_dark/migration.sql
@@ -1,0 +1,20 @@
+-- Theme enum에서 SYSTEM을 제거하기 전에 기존 값을 새 기본 정책인 LIGHT로 보정한다.
+UPDATE "UserSettings"
+SET "theme" = 'LIGHT'
+WHERE "theme" = 'SYSTEM';
+
+ALTER TABLE "UserSettings" ALTER COLUMN "theme" DROP DEFAULT;
+
+-- PostgreSQL enum 값은 직접 삭제할 수 없어 새 enum으로 교체한다.
+CREATE TYPE "Theme_new" AS ENUM ('LIGHT', 'DARK');
+
+ALTER TABLE "UserSettings"
+  ALTER COLUMN "theme" TYPE "Theme_new"
+  USING ("theme"::text::"Theme_new");
+
+ALTER TYPE "Theme" RENAME TO "Theme_old";
+ALTER TYPE "Theme_new" RENAME TO "Theme";
+
+DROP TYPE "Theme_old";
+
+ALTER TABLE "UserSettings" ALTER COLUMN "theme" SET DEFAULT 'LIGHT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,6 @@ enum AuthProvider {
 enum Theme {
   LIGHT
   DARK
-  SYSTEM
 }
 
 // 구독 플랜
@@ -128,7 +127,7 @@ model Workspace {
 
 model UserSettings {
   id       String @id @default(cuid())
-  theme    Theme  @default(SYSTEM)
+  theme    Theme  @default(LIGHT)
   language String @default("ko")
 
   userId String @unique

--- a/src/users/application/usecases/get-user-settings.usecase.spec.ts
+++ b/src/users/application/usecases/get-user-settings.usecase.spec.ts
@@ -28,7 +28,7 @@ describe('GetUserSettingsUseCase', () => {
     repo.upsertUserSettings.mockResolvedValue({
       id: 'settings-id',
       userId: 'user-id',
-      theme: 'SYSTEM',
+      theme: 'LIGHT',
       language: 'ko',
     });
 
@@ -39,7 +39,7 @@ describe('GetUserSettingsUseCase', () => {
     expect(result).toEqual({
       id: 'settings-id',
       userId: 'user-id',
-      theme: 'SYSTEM',
+      theme: 'LIGHT',
       language: 'ko',
     });
   });

--- a/src/users/domain/user.types.ts
+++ b/src/users/domain/user.types.ts
@@ -1,6 +1,6 @@
 import type { AuthProvider } from 'src/shared/types/auth-provider.type';
 
-export const USER_THEMES = ['LIGHT', 'DARK', 'SYSTEM'] as const;
+export const USER_THEMES = ['LIGHT', 'DARK'] as const;
 export type UserTheme = (typeof USER_THEMES)[number];
 
 export const USER_LANGUAGES = ['ko', 'en', 'ja', 'zh'] as const;

--- a/src/users/infrastructure/prisma-users.repository.ts
+++ b/src/users/infrastructure/prisma-users.repository.ts
@@ -11,6 +11,7 @@ import {
   UserLanguage,
   UserSettings,
   UserSummary,
+  UserTheme,
   UserWithAuthAccounts,
 } from '../domain/user.types';
 
@@ -129,6 +130,8 @@ export class PrismaUsersRepository implements UsersRepository {
   private toUserSettings(settings: PrismaUserSettings): UserSettings {
     return {
       ...settings,
+      // 마이그레이션과 요청 검증이 theme 값을 도메인 계약 안으로 제한한다.
+      theme: settings.theme as UserTheme,
       language: settings.language as UserLanguage,
     };
   }

--- a/src/users/presentation/dtos/update-user-settings.dto.ts
+++ b/src/users/presentation/dtos/update-user-settings.dto.ts
@@ -8,7 +8,7 @@ import {
 } from '../../domain/user.types';
 
 export class UpdateUserSettingsDto {
-  @ApiPropertyOptional({ enum: USER_THEMES, example: 'SYSTEM' })
+  @ApiPropertyOptional({ enum: USER_THEMES, example: 'LIGHT' })
   @IsOptional()
   @IsIn(USER_THEMES)
   theme?: UserTheme;

--- a/src/users/presentation/dtos/user-response.dto.ts
+++ b/src/users/presentation/dtos/user-response.dto.ts
@@ -8,47 +8,47 @@ import {
 
 export class UserAuthAccountResponseDto {
   @ApiProperty({ example: 'cmauth123' })
-  id: string;
+  id!: string;
 
   @ApiProperty({ enum: ['GOOGLE', 'GITHUB'], example: 'GOOGLE' })
-  provider: 'GOOGLE' | 'GITHUB';
+  provider!: 'GOOGLE' | 'GITHUB';
 
   @ApiProperty({ example: 'user@example.com' })
-  email: string;
+  email!: string;
 }
 
 export class UserProfileResponseDto {
   @ApiProperty({ example: 'cmuser123' })
-  id: string;
+  id!: string;
 
   @ApiProperty({ example: '홍길동' })
-  displayName: string;
+  displayName!: string;
 
   @ApiProperty({
     example: 'https://avatars.githubusercontent.com/u/1?v=4',
     nullable: true,
   })
-  avatarUrl: string | null;
+  avatarUrl!: string | null;
 
   @ApiProperty({ type: [UserAuthAccountResponseDto] })
-  authAccounts: UserAuthAccountResponseDto[];
+  authAccounts!: UserAuthAccountResponseDto[];
 }
 
 export class UserSettingsResponseDto {
   @ApiProperty({ example: 'cmsettings123' })
-  id: string;
+  id!: string;
 
   @ApiProperty({ example: 'cmuser123' })
-  userId: string;
+  userId!: string;
 
-  @ApiProperty({ enum: USER_THEMES, example: 'SYSTEM' })
-  theme: UserTheme;
+  @ApiProperty({ enum: USER_THEMES, example: 'LIGHT' })
+  theme!: UserTheme;
 
   @ApiProperty({ enum: USER_LANGUAGES, example: 'ko' })
-  language: UserLanguage;
+  language!: UserLanguage;
 }
 
 export class DeleteMeResponseDto {
   @ApiProperty({ example: true })
-  success: true;
+  success!: true;
 }


### PR DESCRIPTION
## Description

테마 설정에서 `SYSTEM` 값을 제거하고 `LIGHT`, `DARK` 두 값만 허용하도록 제한합니다. 기존 `SYSTEM` 저장 데이터는 마이그레이션에서 `LIGHT`로 보정한 뒤 PostgreSQL enum을 교체합니다.

## Type of change

- 중대한 변경 (수정/기능으로 인해 기존 동작이 깨질 수 있음)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #125

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- `USER_THEMES`와 Prisma `Theme` enum에서 `SYSTEM` 제거
- `UserSettings.theme` 기본값을 `LIGHT`로 변경
- 기존 `SYSTEM` 데이터를 `LIGHT`로 보정하고 enum을 재생성하는 Prisma 마이그레이션 추가
- 설정 요청/응답 Swagger 예시와 기본 설정 use case 테스트 기대값 갱신
- 응답 DTO 필드에 definite assignment assertion을 적용해 class DTO 초기화 오류 정리

## Performance/Scaling

- N/A

## Testing done

- `pnpm lint`: 통과
- `pnpm test`: 통과
- `pnpm test:e2e`: 통과
- `pnpm build`: 통과
- `pnpm exec prisma validate`: 통과

## Additional information

- 로컬 DB에 마이그레이션을 실제 적용하지는 않았고, 마이그레이션 파일과 Prisma schema 유효성만 검증했습니다.