### PR TITLE
#127/chore(chore) : Lightsail Docker 배포 구성 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+dist
+coverage
+.git
+.github
+.codex
+.agents
+.env
+.env.*
+!.env.production.example
+!.env.local.example
+npm-debug.log*
+pnpm-debug.log*
+Dockerfile
+docker/*.yml
+docker/*.yaml

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,7 +1,11 @@
 NODE_ENV=production
 PORT=3000
 
-DATABASE_URL=postgresql://USER:PASSWORD@RDS_HOST:5432/DB_NAME
+POSTGRES_USER=easy_clip
+POSTGRES_PASSWORD=replace_with_strong_postgres_password
+POSTGRES_DB=easy_clip
+DATABASE_URL=postgresql://easy_clip:replace_with_strong_postgres_password@postgres:5432/easy_clip?schema=public
+API_DOMAIN=api.example.com
 JWT_ACCESS_SECRET=replace_with_production_access_secret
 JWT_REFRESH_SECRET=replace_with_production_refresh_secret
 OAUTH_STATE_SECRET=replace_with_oauth_state_secret

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,18 +4,21 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Deploy to EC2
+      - name: Deploy to Lightsail
         uses: appleboy/ssh-action@v1.2.0
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          host: ${{ secrets.LIGHTSAIL_HOST }}
+          username: ${{ secrets.LIGHTSAIL_USER }}
+          key: ${{ secrets.LIGHTSAIL_SSH_KEY }}
+          script_stop: true
           script: |
-            cd /home/ec2-user/easy-clip-be
+            APP_DIR="${{ secrets.LIGHTSAIL_APP_DIR }}"
+            cd "${APP_DIR:-/home/ubuntu/easy-clip-be}"
             ./deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM node:22-bookworm-slim AS base
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+RUN corepack enable && corepack prepare pnpm@10.27.0 --activate
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+FROM base AS deps
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM deps AS build
+
+COPY nest-cli.json prisma.config.ts tsconfig*.json ./
+COPY prisma ./prisma
+COPY src ./src
+RUN DATABASE_URL="postgresql://easy_clip:easy_clip@localhost:5432/easy_clip?schema=public" pnpm prisma generate
+RUN pnpm build
+RUN pnpm prune --prod
+
+FROM base AS runner
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+
+EXPOSE 3000
+
+CMD ["sh", "-c", "pnpm prisma migrate deploy && node dist/src/main.js"]

--- a/README.md
+++ b/README.md
@@ -278,21 +278,14 @@ CI에서는 PostgreSQL 서비스 컨테이너를 띄운 뒤 아래 순서로 검
 
 ## Deployment
 
-운영 배포는 EC2 + PM2 + GitHub Actions 기반으로 구성합니다.
+운영 배포는 Lightsail 단일 인스턴스 + Docker Compose + GitHub Actions 기반으로 구성합니다.
 
-### EC2 Runtime
+### Lightsail Runtime
 
-- 서버 경로: `/home/ec2-user/easy-clip-be`
-- 프로세스 매니저: `pm2`
-- 실행 엔트리: `pnpm start:prod`
-
-PM2 예시:
-
-```bash
-export NODE_ENV=production
-pm2 start dist/src/main.js --name easy-clip-be --interpreter node --update-env
-pm2 save
-```
+- 서버 경로 기본값: `/home/ubuntu/easy-clip-be`
+- 실행 구성: `docker/docker-compose.production.yml`
+- 서비스: `api`, `postgres`, `nginx`
+- 운영 환경 파일: `.env.production`
 
 ### Deploy Script
 
@@ -302,35 +295,33 @@ pm2 save
 
 동작 순서:
 
-1. `git pull origin main`
-2. `pnpm install --frozen-lockfile`
-3. `pnpm prisma generate`
-4. `pnpm prisma migrate deploy`
-5. `pnpm build`
-6. `pm2 restart easy-clip-be --update-env`
-7. `pm2 save`
+1. `git fetch origin main`
+2. `git reset --hard origin/main`
+3. `docker compose --env-file .env.production -f docker/docker-compose.production.yml up -d --build --remove-orphans`
+4. `docker image prune -f`
 
 ### GitHub Actions
 
 - PR 검증: `.github/workflows/ci.yml`
 - 운영 배포: `.github/workflows/deploy.yml`
 
-배포 워크플로우는 `main` 브랜치 push 시 동작하며, `appleboy/ssh-action`을 통해 EC2에서 `deploy.sh`를 실행합니다.
+배포 워크플로우는 `main` 브랜치 push 시 동작하며, `appleboy/ssh-action`을 통해 Lightsail 인스턴스에서 `deploy.sh`를 실행합니다.
 
 필요한 GitHub Secrets:
 
-- `EC2_HOST`
-- `EC2_USER`
-- `EC2_SSH_KEY`
+- `LIGHTSAIL_HOST`
+- `LIGHTSAIL_USER`
+- `LIGHTSAIL_SSH_KEY`
+- `LIGHTSAIL_APP_DIR` (선택, 기본값: `/home/ubuntu/easy-clip-be`)
 
 ## Operational Notes
 
-- Prisma 관련 명령과 운영 실행은 `NODE_ENV=production` 기준으로 수행합니다.
-- RDS 접속 오류가 발생하면 먼저 `DATABASE_URL`, 사용자명, 비밀번호, DB 이름, `sslmode=require` 여부를 확인합니다.
+- Prisma migration은 API 컨테이너 시작 시 `prisma migrate deploy`로 수행합니다.
+- DB 접속 오류가 발생하면 먼저 `DATABASE_URL`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`를 확인합니다.
 - 앱 실행 실패 시 우선 확인 순서:
-  - `pnpm build`
-  - `pnpm start:prod`
-  - `pm2 logs easy-clip-be`
+  - `docker compose --env-file .env.production -f docker/docker-compose.production.yml ps`
+  - `docker compose --env-file .env.production -f docker/docker-compose.production.yml logs -f api`
+  - `docker compose --env-file .env.production -f docker/docker-compose.production.yml logs -f nginx`
 
 ## Repository Conventions
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
-cd /home/ec2-user/easy-clip-be
+APP_DIR="${APP_DIR:-/home/ubuntu/easy-clip-be}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker/docker-compose.production.yml}"
+ENV_FILE="${ENV_FILE:-.env.production}"
 
-export NODE_ENV=production
+cd "$APP_DIR"
 
-git pull origin main
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing $ENV_FILE. Create it from .env.production.example before deploying." >&2
+  exit 1
+fi
 
-pnpm install --frozen-lockfile
-pnpm prisma generate
-pnpm prisma migrate deploy
-pnpm build
+git fetch origin main
+git reset --hard origin/main
 
-pm2 restart easy-clip-be --update-env
-pm2 save
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --build --remove-orphans
+docker image prune -f

--- a/docker/README.production.md
+++ b/docker/README.production.md
@@ -1,0 +1,81 @@
+# Lightsail 운영 배포 메모
+
+이 문서는 Lightsail 단일 인스턴스에서 API, PostgreSQL, Nginx를 Docker Compose로 실행하기 위한 최소 절차를 정리한다.
+
+## 구성
+
+- `api`: NestJS 애플리케이션 컨테이너
+- `postgres`: PostgreSQL 컨테이너
+- `nginx`: HTTP 리버스 프록시
+- `postgres-data`: PostgreSQL 데이터 볼륨
+
+## 최초 설정
+
+운영 서버에서 `.env.production.example`을 기준으로 `.env.production`을 만든다.
+
+```bash
+cp .env.production.example .env.production
+```
+
+최소한 다음 값은 실제 운영 값으로 교체한다.
+
+```text
+POSTGRES_PASSWORD
+DATABASE_URL
+API_DOMAIN
+JWT_ACCESS_SECRET
+JWT_REFRESH_SECRET
+OAUTH_STATE_SECRET
+CORS_ALLOWED_ORIGINS
+R2_ACCOUNT_ID
+R2_ACCESS_KEY_ID
+R2_SECRET_ACCESS_KEY
+R2_BUCKET_NAME
+R2_PUBLIC_BASE_URL
+GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET
+GOOGLE_REDIRECT_URI
+GITHUB_CLIENT_ID
+GITHUB_CLIENT_SECRET
+GITHUB_REDIRECT_URI
+```
+
+`DATABASE_URL`은 compose 내부의 `postgres` 서비스를 바라봐야 한다.
+
+```text
+postgresql://easy_clip:<POSTGRES_PASSWORD>@postgres:5432/easy_clip?schema=public
+```
+
+## 실행
+
+설정 파일을 먼저 검증한다.
+
+```bash
+docker compose --env-file .env.production -f docker/docker-compose.production.yml config
+```
+
+이미지를 빌드하고 서비스를 실행한다.
+
+```bash
+docker compose --env-file .env.production -f docker/docker-compose.production.yml up -d --build
+```
+
+로그 확인:
+
+```bash
+docker compose --env-file .env.production -f docker/docker-compose.production.yml logs -f api
+```
+
+상태 확인:
+
+```bash
+docker compose --env-file .env.production -f docker/docker-compose.production.yml ps
+```
+
+## DNS
+
+Cloudflare DNS에서 `API_DOMAIN`에 해당하는 A 레코드를 Lightsail 고정 IP로 연결한다.
+
+Nginx가 80 포트로 API 컨테이너에 프록시하므로 Lightsail 방화벽과 OS 방화벽에서 `80` 포트를 허용해야 한다.
+
+HTTPS는 별도 단계에서 Cloudflare 프록시와 Origin Certificate 또는 certbot 방식 중 하나로 구성한다.

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -1,0 +1,56 @@
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: easy-clip-api:latest
+    container_name: easyclip-api
+    restart: unless-stopped
+    env_file:
+      - ${APP_ENV_FILE:-../.env.production}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - easyclip
+
+  postgres:
+    image: postgres:18
+    container_name: easyclip-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres-data:/var/lib/postgresql
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - easyclip
+
+  nginx:
+    image: nginx:stable-alpine
+    container_name: easyclip-nginx
+    restart: unless-stopped
+    environment:
+      API_DOMAIN: ${API_DOMAIN}
+    ports:
+      - '80:80'
+    volumes:
+      - ./nginx/templates:/etc/nginx/templates:ro
+    depends_on:
+      - api
+    networks:
+      - easyclip
+
+volumes:
+  postgres-data:
+
+networks:
+  easyclip:
+    driver: bridge

--- a/docker/nginx/templates/easyclip.conf.template
+++ b/docker/nginx/templates/easyclip.conf.template
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name ${API_DOMAIN};
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_pass http://api:3000;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+}


### PR DESCRIPTION
## Description

Lightsail 단일 인스턴스에서 API, PostgreSQL, Nginx를 Docker Compose로 운영 배포할 수 있도록 구성합니다.

## Type of change

- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)

## Linked tickets and other PRs

- Closes #127

## TODOs

- [x] 변경 사항 셀프 리뷰
- [ ] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- 운영용 Dockerfile과 docker compose 구성을 추가했습니다.
- GitHub Actions 배포 대상을 Lightsail SSH 접속으로 변경했습니다.
- deploy.sh가 main 최신 커밋 기준으로 컨테이너를 재빌드/재기동하도록 변경했습니다.
- 운영 배포 문서와 환경 변수 예제를 갱신했습니다.

## Testing done

- `npm run build`: 통과
- `docker compose --env-file .env.production.example -f docker/docker-compose.production.yml config`: 통과
- `pnpm lint`: 미실행
- `pnpm test`: 미실행
- `pnpm test:e2e`: 미실행

## Additional information

- 실제 운영 비밀값은 커밋하지 않았고, 서버의 `.env.production` 및 GitHub Secrets에서 관리합니다.