### PR TITLE
#127/hotfix(chore) : Nginx HTTPS origin 설정 추가

### DIFF
--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -41,8 +41,10 @@ services:
       API_DOMAIN: ${API_DOMAIN}
     ports:
       - '80:80'
+      - '443:443'
     volumes:
       - ./nginx/templates:/etc/nginx/templates:ro
+      - ${NGINX_CERT_DIR:-/etc/easyclip/certs}:/etc/nginx/certs:ro
     depends_on:
       - api
     networks:

--- a/docker/nginx/templates/easyclip.conf.template
+++ b/docker/nginx/templates/easyclip.conf.template
@@ -2,6 +2,16 @@ server {
     listen 80;
     server_name ${API_DOMAIN};
 
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name ${API_DOMAIN};
+
+    ssl_certificate /etc/nginx/certs/origin.pem;
+    ssl_certificate_key /etc/nginx/certs/origin.key;
+
     client_max_body_size 10m;
 
     location / {


### PR DESCRIPTION
## Description

Cloudflare Full strict 환경에서 Lightsail origin이 HTTPS로 응답할 수 있도록 Nginx 운영 설정을 보완합니다.

## Type of change

- 내부 변경 (버그 수정이나 신규 기능이 아닐 수 있음)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Refs #127

## TODOs

- [x] 변경 사항 셀프 리뷰
- [ ] 테스트 코드 작성
- [x] 수동 테스트 수행

## Implementation

- 운영 Docker Compose의 Nginx 서비스에 443 포트 바인딩을 추가했습니다.
- 서버 전용 Cloudflare Origin Certificate 경로를 Nginx 컨테이너에 읽기 전용으로 마운트합니다.
- Nginx 템플릿에 HTTP to HTTPS 리다이렉트와 443 SSL 프록시 서버 블록을 추가했습니다.

## Testing done

- `docker compose --env-file .env.production.example -f docker/docker-compose.production.yml config`: 통과
- `pnpm test`: 통과
- `pnpm test:e2e`: 통과
- `pnpm lint`: 미실행

## Additional information

- 인증서와 개인키는 서버의 `/etc/easyclip/certs`에 배치하며 Git에 포함하지 않습니다.
- 서버 배포 전 `origin.pem`, `origin.key` 파일이 존재해야 Nginx가 정상 기동됩니다.
