### PR TITLE
#132/fix(clip) : 폴더 범위 클립 전체 삭제 적용

### DIFF
--- a/src/clips/application/usecases/create-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/create-clip.usecase.spec.ts
@@ -23,7 +23,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 const createImageStorage = (): jest.Mocked<ClipImageStoragePort> => ({

--- a/src/clips/application/usecases/delete-all-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/delete-all-clips.usecase.spec.ts
@@ -21,27 +21,56 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('DeleteAllClipsUseCase', () => {
-  it('사용자 소유 클립을 전체 소프트 삭제한다', async () => {
+  it('사용자가 접근할 수 있는 폴더의 클립을 전체 소프트 삭제한다', async () => {
     const repo = createRepository();
-    repo.softDeleteAllClipsForUser.mockResolvedValue(3);
+    repo.findPersonalFolderById.mockResolvedValue({
+      id: 'folder-id',
+      workspaceId: 'workspace-id',
+    });
+    repo.softDeleteAllClipsInFolder.mockResolvedValue(3);
 
     const usecase = new DeleteAllClipsUseCase(repo);
-    const result = await usecase.execute('user-id');
+    const result = await usecase.execute('user-id', 'folder-id');
 
-    expect(repo.softDeleteAllClipsForUser).toHaveBeenCalledWith('user-id');
+    expect(repo.findPersonalFolderById).toHaveBeenCalledWith(
+      'user-id',
+      'folder-id',
+    );
+    expect(repo.softDeleteAllClipsInFolder).toHaveBeenCalledWith(
+      'user-id',
+      'folder-id',
+    );
     expect(result).toEqual({ deletedCount: 3 });
   });
 
-  it('삭제할 클립이 없어도 0개 삭제 결과를 반환한다', async () => {
+  it('접근할 수 없는 폴더면 NOT_FOUND를 반환하고 삭제하지 않는다', async () => {
     const repo = createRepository();
-    repo.softDeleteAllClipsForUser.mockResolvedValue(0);
+    repo.findPersonalFolderById.mockResolvedValue(null);
 
     const usecase = new DeleteAllClipsUseCase(repo);
-    const result = await usecase.execute('user-id');
+
+    await expect(usecase.execute('user-id', 'folder-id')).rejects.toMatchObject(
+      {
+        code: 'NOT_FOUND',
+      },
+    );
+    expect(repo.softDeleteAllClipsInFolder).not.toHaveBeenCalled();
+  });
+
+  it('삭제할 활성 클립이 없어도 0개 삭제 결과를 반환한다', async () => {
+    const repo = createRepository();
+    repo.findPersonalFolderById.mockResolvedValue({
+      id: 'folder-id',
+      workspaceId: 'workspace-id',
+    });
+    repo.softDeleteAllClipsInFolder.mockResolvedValue(0);
+
+    const usecase = new DeleteAllClipsUseCase(repo);
+    const result = await usecase.execute('user-id', 'folder-id');
 
     expect(result).toEqual({ deletedCount: 0 });
   });

--- a/src/clips/application/usecases/delete-all-clips.usecase.ts
+++ b/src/clips/application/usecases/delete-all-clips.usecase.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { CLIPS_REPOSITORY } from '../../domain/clips.repository';
 import type { ClipsRepository } from '../../domain/clips.repository';
 import type { DeleteClipsOutput } from '../dtos/delete-clips-output.dto';
+import { ClipsError } from '../errors/clips.error';
 
 @Injectable()
 export class DeleteAllClipsUseCase {
@@ -10,9 +11,20 @@ export class DeleteAllClipsUseCase {
     private readonly clipsRepository: ClipsRepository,
   ) {}
 
-  async execute(userId: string): Promise<DeleteClipsOutput> {
-    const deletedCount =
-      await this.clipsRepository.softDeleteAllClipsForUser(userId);
+  async execute(userId: string, folderId: string): Promise<DeleteClipsOutput> {
+    const folder = await this.clipsRepository.findPersonalFolderById(
+      userId,
+      folderId,
+    );
+
+    if (!folder) {
+      throw new ClipsError('NOT_FOUND', '폴더를 찾을 수 없습니다.');
+    }
+
+    const deletedCount = await this.clipsRepository.softDeleteAllClipsInFolder(
+      userId,
+      folder.id,
+    );
 
     return { deletedCount };
   }

--- a/src/clips/application/usecases/delete-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/delete-clip.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('DeleteClipUseCase', () => {

--- a/src/clips/application/usecases/delete-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/delete-clips.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('DeleteClipsUseCase', () => {

--- a/src/clips/application/usecases/like-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/like-clip.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('LikeClipUseCase', () => {

--- a/src/clips/application/usecases/list-favorite-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-favorite-clips.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('ListFavoriteClipsUseCase', () => {

--- a/src/clips/application/usecases/list-folder-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-folder-clips.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 const createClips = (count: number, prefix = 'clip') =>

--- a/src/clips/application/usecases/list-recent-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-recent-clips.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('ListRecentClipsUseCase', () => {

--- a/src/clips/application/usecases/list-recent-viewed-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-recent-viewed-clips.usecase.spec.ts
@@ -24,7 +24,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 const createClipItem = (id: string) => ({

--- a/src/clips/application/usecases/record-clip-view.usecase.spec.ts
+++ b/src/clips/application/usecases/record-clip-view.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('RecordClipViewUseCase', () => {

--- a/src/clips/application/usecases/unlike-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/unlike-clip.usecase.spec.ts
@@ -21,7 +21,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 describe('UnlikeClipUseCase', () => {

--- a/src/clips/application/usecases/update-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/update-clip.usecase.spec.ts
@@ -24,7 +24,7 @@ const createRepository = (): jest.Mocked<ClipsRepository> => ({
   updateClip: jest.fn(),
   softDeleteClip: jest.fn(),
   softDeleteClips: jest.fn(),
-  softDeleteAllClipsForUser: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
 });
 
 const createImageStorage = (): jest.Mocked<ClipImageStoragePort> => ({

--- a/src/clips/domain/clips.repository.ts
+++ b/src/clips/domain/clips.repository.ts
@@ -86,5 +86,5 @@ export interface ClipsRepository {
   updateClip(clipId: string, params: UpdateClipParams): Promise<Clip>;
   softDeleteClip(clipId: string): Promise<Clip>;
   softDeleteClips(clipIds: string[]): Promise<number>;
-  softDeleteAllClipsForUser(userId: string): Promise<number>;
+  softDeleteAllClipsInFolder(userId: string, folderId: string): Promise<number>;
 }

--- a/src/clips/infrastructure/prisma-clips.repository.ts
+++ b/src/clips/infrastructure/prisma-clips.repository.ts
@@ -418,12 +418,19 @@ export class PrismaClipsRepository implements ClipsRepository {
     return result.count;
   }
 
-  async softDeleteAllClipsForUser(userId: string): Promise<number> {
+  async softDeleteAllClipsInFolder(
+    userId: string,
+    folderId: string,
+  ): Promise<number> {
     const result = await this.prisma.clip.updateMany({
       where: {
+        folderId,
         deletedAt: null,
         folder: {
           deletedAt: null,
+          workspace: {
+            ownerUserId: userId,
+          },
         },
         workspace: {
           ownerUserId: userId,

--- a/src/clips/presentation/clips.controller.ts
+++ b/src/clips/presentation/clips.controller.ts
@@ -213,15 +213,23 @@ export class ClipsController {
     );
   }
 
-  @Delete('all')
+  @Delete('all/:folderId')
   @UseGuards(JwtAccessGuard)
   @ApiOperation({ summary: '클립 전체 삭제' })
+  @ApiParam({ name: 'folderId', description: '폴더 ID' })
   @ApiOkResponse({
     description: '소프트 삭제된 클립 개수를 반환합니다.',
     type: DeleteClipsResponseDto,
   })
-  deleteAllClips(@Request() req: { user: AuthContext }) {
-    return this.deleteAllClipsUseCase.execute(req.user.userId);
+  @ApiNotFoundResponse({
+    description: '폴더를 찾을 수 없습니다.',
+    type: ErrorResponseDto,
+  })
+  deleteAllClips(
+    @Request() req: { user: AuthContext },
+    @Param('folderId') folderId: string,
+  ) {
+    return this.deleteAllClipsUseCase.execute(req.user.userId, folderId);
   }
 
   @Delete(':id')


### PR DESCRIPTION
## Description

클립 전체 삭제 API가 요청한 폴더의 활성 클립만 소프트 삭제하도록 수정했습니다.

## Type of change

- 버그 수정 (호환성에 영향을 주지 않는 문제 해결)
- 사용자에게 직접 영향을 주는 변경

## Linked tickets and other PRs

- Closes #132

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 작성
- [ ] 수동 테스트 수행

## Implementation

- DELETE /clips/all/:folderId 경로로 폴더 ID를 받도록 변경
- 유스케이스에서 사용자 접근 가능 폴더를 검증하고, 없으면 NOT_FOUND를 반환
- Prisma 저장소의 소프트 삭제 범위를 해당 폴더와 사용자 소유 워크스페이스로 제한

## Performance/Scaling

- 해당 없음

## Testing done

- pnpm test -- --runInBand src/clips/application/usecases: 12개 스위트, 47개 테스트 통과
- pnpm exec eslint "{src,apps,libs,test}/**/*.ts" --no-fix: 통과
- pnpm build: 통과
- pnpm test:e2e -- --runInBand: e2e-spec.ts 파일이 없어 Jest가 No tests found로 종료

## Additional information

- 기존 DELETE /clips/all 엔드포인트는 DELETE /clips/all/:folderId로 변경됩니다.