### PR TITLE
#134/refactor(test) : 도메인별 Repository mock 팩토리 공통화

### DIFF
--- a/.codex/skills/git-workflow/SKILL.md
+++ b/.codex/skills/git-workflow/SKILL.md
@@ -59,7 +59,7 @@ Examples:
 Validate the title with this regular expression:
 
 ```regex
-^#[1-9][0-9]*/(chore|feat|refactor|fix|docs|style|hotfix|release)\((chore|docs|test|auth|user|clip|setting)\) : .+$
+^#[1-9][0-9]*/(chore|feat|refactor|fix|docs|style|hotfix|release)\((chore|docs|test|auth|user|clip|folder|subscriptions|trash|setting)\) : .+$
 ```
 
 - Put the related issue number first. Never substitute the PR number for the related issue number.
@@ -79,7 +79,7 @@ Allowed types:
 - `hotfix`: Urgent change that bypasses the normal release flow
 - `release`: Versioning, tags, deployment, and `dev → main` promotion
 
-Allowed scopes are `chore`, `docs`, `test`, `auth`, `user`, `clip`, and `setting`. If none fits, do not invent a new scope; ask the maintainer whether to extend the policy.
+Allowed scopes are `chore`, `docs`, `test`, `auth`, `user`, `clip`, `folder`, `subscriptions`, `trash`, and `setting`. If none fits, do not invent a new scope; ask the maintainer whether to extend the policy.
 
 ## Commit Changes
 

--- a/src/auth/application/usecases/link-account.usecase.spec.ts
+++ b/src/auth/application/usecases/link-account.usecase.spec.ts
@@ -1,17 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { LinkAccountUseCase } from './link-account.usecase';
-import type { AuthRepository } from '../../domain/auth.repository';
+import { createAuthRepositoryMock } from '../../test-support/create-auth-repository-mock';
 import type { AuthSessionPort } from '../ports/auth-session.port';
 import { OAuthUser } from '../../domain/auth.types';
-
-const createRepository = (): jest.Mocked<AuthRepository> => ({
-  findAccountByProvider: jest.fn(),
-  findAccountById: jest.fn(),
-  findUserById: jest.fn(),
-  findUserByAuthEmail: jest.fn(),
-  createUserWithAuthAccount: jest.fn(),
-  createAuthAccountForUser: jest.fn(),
-});
 
 const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
@@ -37,7 +28,7 @@ const createOAuthUser = (overrides: Partial<OAuthUser> = {}): OAuthUser => ({
 
 describe('LinkAccountUseCase', () => {
   it('로그인이 없으면 FORBIDDEN 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new LinkAccountUseCase(repo, sessionPort);
 
@@ -47,7 +38,7 @@ describe('LinkAccountUseCase', () => {
   });
 
   it('이메일이 없으면 BAD_REQUEST 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new LinkAccountUseCase(repo, sessionPort);
 
@@ -57,7 +48,7 @@ describe('LinkAccountUseCase', () => {
   });
 
   it('사용자가 없으면 NOT_FOUND 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findUserById.mockResolvedValue(null);
 
@@ -69,7 +60,7 @@ describe('LinkAccountUseCase', () => {
   });
 
   it('이미 연동된 계정이면 CONFLICT 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findUserById.mockResolvedValue({ id: 'current-user-id' });
     repo.findAccountByProvider.mockResolvedValue({
@@ -90,7 +81,7 @@ describe('LinkAccountUseCase', () => {
   });
 
   it('정상적인 요청이면 계정을 생성하고 토큰을 발급한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findUserById.mockResolvedValue({ id: 'current-user-id' });
     repo.findAccountByProvider.mockResolvedValue(null);

--- a/src/auth/application/usecases/sign-in.usecase.spec.ts
+++ b/src/auth/application/usecases/sign-in.usecase.spec.ts
@@ -1,17 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { SignInUseCase } from './sign-in.usecase';
-import type { AuthRepository } from '../../domain/auth.repository';
+import { createAuthRepositoryMock } from '../../test-support/create-auth-repository-mock';
 import type { AuthSessionPort } from '../ports/auth-session.port';
 import { OAuthUser } from '../../domain/auth.types';
-
-const createRepository = (): jest.Mocked<AuthRepository> => ({
-  findAccountByProvider: jest.fn(),
-  findAccountById: jest.fn(),
-  findUserById: jest.fn(),
-  findUserByAuthEmail: jest.fn(),
-  createUserWithAuthAccount: jest.fn(),
-  createAuthAccountForUser: jest.fn(),
-});
 
 const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
@@ -36,7 +27,7 @@ const createOAuthUser = (overrides: Partial<OAuthUser> = {}): OAuthUser => ({
 
 describe('SignInUseCase', () => {
   it('이메일이 없으면 BAD_REQUEST 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new SignInUseCase(repo, sessionPort);
 
@@ -46,7 +37,7 @@ describe('SignInUseCase', () => {
   });
 
   it('기존 계정이 있으면 토큰을 발급한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountByProvider.mockResolvedValue({
       id: 'account-id',
@@ -84,7 +75,7 @@ describe('SignInUseCase', () => {
   });
 
   it('동일 이메일 사용자가 있으면 CONFLICT 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountByProvider.mockResolvedValue(null);
     repo.findUserByAuthEmail.mockResolvedValue({ id: 'user-id' });
@@ -97,7 +88,7 @@ describe('SignInUseCase', () => {
   });
 
   it('신규 계정이면 계정을 생성하고 토큰을 발급한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountByProvider.mockResolvedValue(null);
     repo.findUserByAuthEmail.mockResolvedValue(null);

--- a/src/auth/application/usecases/switch-user.usecase.spec.ts
+++ b/src/auth/application/usecases/switch-user.usecase.spec.ts
@@ -1,16 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { SwitchUserUseCase } from './switch-user.usecase';
-import type { AuthRepository } from '../../domain/auth.repository';
+import { createAuthRepositoryMock } from '../../test-support/create-auth-repository-mock';
 import type { AuthSessionPort } from '../ports/auth-session.port';
-
-const createRepository = (): jest.Mocked<AuthRepository> => ({
-  findAccountByProvider: jest.fn(),
-  findAccountById: jest.fn(),
-  findUserById: jest.fn(),
-  findUserByAuthEmail: jest.fn(),
-  createUserWithAuthAccount: jest.fn(),
-  createAuthAccountForUser: jest.fn(),
-});
 
 const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
@@ -24,7 +15,7 @@ const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
 
 describe('SwitchUserUseCase', () => {
   it('계정이 없으면 NOT_FOUND 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountById.mockResolvedValue(null);
 
@@ -36,7 +27,7 @@ describe('SwitchUserUseCase', () => {
   });
 
   it('현재 사용자와 계정이 다르면 FORBIDDEN 오류를 반환한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountById.mockResolvedValue({
       id: 'account-id',
@@ -56,7 +47,7 @@ describe('SwitchUserUseCase', () => {
   });
 
   it('정상적인 요청이면 토큰을 발급한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountById.mockResolvedValue({
       id: 'account-id',

--- a/src/auth/application/usecases/test-admin-login.usecase.spec.ts
+++ b/src/auth/application/usecases/test-admin-login.usecase.spec.ts
@@ -1,16 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { TestAdminLoginUseCase } from './test-admin-login.usecase';
-import type { AuthRepository } from '../../domain/auth.repository';
+import { createAuthRepositoryMock } from '../../test-support/create-auth-repository-mock';
 import type { AuthSessionPort } from '../ports/auth-session.port';
-
-const createRepository = (): jest.Mocked<AuthRepository> => ({
-  findAccountByProvider: jest.fn(),
-  findAccountById: jest.fn(),
-  findUserById: jest.fn(),
-  findUserByAuthEmail: jest.fn(),
-  createUserWithAuthAccount: jest.fn(),
-  createAuthAccountForUser: jest.fn(),
-});
 
 const createSessionPort = (): jest.Mocked<AuthSessionPort> => ({
   issueTokens: jest.fn(),
@@ -57,7 +48,7 @@ const createInput = () => ({
 
 describe('TestAdminLoginUseCase', () => {
   it('운영 환경에서는 테스트 관리자 로그인을 거부한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new TestAdminLoginUseCase(repo, sessionPort);
 
@@ -74,7 +65,7 @@ describe('TestAdminLoginUseCase', () => {
   });
 
   it('feature flag가 꺼져 있으면 테스트 관리자 로그인을 거부한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new TestAdminLoginUseCase(repo, sessionPort);
 
@@ -91,7 +82,7 @@ describe('TestAdminLoginUseCase', () => {
   });
 
   it('시크릿이 설정되어 있지 않으면 테스트 관리자 로그인을 거부한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new TestAdminLoginUseCase(repo, sessionPort);
 
@@ -108,7 +99,7 @@ describe('TestAdminLoginUseCase', () => {
   });
 
   it('요청 시크릿이 없으면 테스트 관리자 로그인을 거부한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new TestAdminLoginUseCase(repo, sessionPort);
 
@@ -125,7 +116,7 @@ describe('TestAdminLoginUseCase', () => {
   });
 
   it('요청 시크릿이 일치하지 않으면 테스트 관리자 로그인을 거부한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     const usecase = new TestAdminLoginUseCase(repo, sessionPort);
 
@@ -142,7 +133,7 @@ describe('TestAdminLoginUseCase', () => {
   });
 
   it('기존 테스트 관리자 계정이 있으면 바로 토큰을 발급한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountByProvider.mockResolvedValue(createAccount());
     sessionPort.issueTokens.mockResolvedValue({
@@ -166,7 +157,7 @@ describe('TestAdminLoginUseCase', () => {
   });
 
   it('동일 이메일 사용자가 있으면 테스트 관리자 계정을 연결한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountByProvider.mockResolvedValue(null);
     repo.findUserByAuthEmail.mockResolvedValue({ id: 'user-id' });
@@ -198,7 +189,7 @@ describe('TestAdminLoginUseCase', () => {
   });
 
   it('동일 이메일 사용자가 없으면 테스트 관리자 사용자를 생성한다', async () => {
-    const repo = createRepository();
+    const repo = createAuthRepositoryMock();
     const sessionPort = createSessionPort();
     repo.findAccountByProvider.mockResolvedValue(null);
     repo.findUserByAuthEmail.mockResolvedValue(null);

--- a/src/auth/test-support/create-auth-repository-mock.ts
+++ b/src/auth/test-support/create-auth-repository-mock.ts
@@ -1,0 +1,10 @@
+import type { AuthRepository } from '../domain/auth.repository';
+
+export const createAuthRepositoryMock = (): jest.Mocked<AuthRepository> => ({
+  findAccountByProvider: jest.fn(),
+  findAccountById: jest.fn(),
+  findUserById: jest.fn(),
+  findUserByAuthEmail: jest.fn(),
+  createUserWithAuthAccount: jest.fn(),
+  createAuthAccountForUser: jest.fn(),
+});

--- a/src/clips/application/usecases/create-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/create-clip.usecase.spec.ts
@@ -1,30 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { CreateClipUseCase } from './create-clip.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 import { MulterFile } from 'src/shared/types/multer-file.type';
 import { ClipImageStoragePort } from 'src/shared/application/ports/clip-image-storage.port';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
 
 const createImageStorage = (): jest.Mocked<ClipImageStoragePort> => ({
   uploadImage: jest.fn(),

--- a/src/clips/application/usecases/delete-all-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/delete-all-clips.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { DeleteAllClipsUseCase } from './delete-all-clips.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 describe('DeleteAllClipsUseCase', () => {
   it('사용자가 접근할 수 있는 폴더의 클립을 전체 소프트 삭제한다', async () => {

--- a/src/clips/application/usecases/delete-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/delete-clip.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { DeleteClipUseCase } from './delete-clip.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 describe('DeleteClipUseCase', () => {
   it('클립이 없으면 NOT_FOUND 오류를 반환한다', async () => {

--- a/src/clips/application/usecases/delete-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/delete-clips.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { DeleteClipsUseCase } from './delete-clips.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 describe('DeleteClipsUseCase', () => {
   it('여러 클립을 소프트 삭제한다', async () => {

--- a/src/clips/application/usecases/like-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/like-clip.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { LikeClipUseCase } from './like-clip.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 describe('LikeClipUseCase', () => {
   it('클립이 없으면 NOT_FOUND 오류를 반환한다', async () => {

--- a/src/clips/application/usecases/list-favorite-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-favorite-clips.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ListFavoriteClipsUseCase } from './list-favorite-clips.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 describe('ListFavoriteClipsUseCase', () => {
   it('좋아요된 클립만 조회한다', async () => {

--- a/src/clips/application/usecases/list-folder-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-folder-clips.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ListFolderClipsUseCase } from './list-folder-clips.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 const createClips = (count: number, prefix = 'clip') =>
   Array.from({ length: count }, (_, index) => ({

--- a/src/clips/application/usecases/list-recent-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-recent-clips.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ListRecentClipsUseCase } from './list-recent-clips.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 describe('ListRecentClipsUseCase', () => {
   it('조회 기록 기준으로 목록을 반환한다', async () => {

--- a/src/clips/application/usecases/list-recent-viewed-clips.usecase.spec.ts
+++ b/src/clips/application/usecases/list-recent-viewed-clips.usecase.spec.ts
@@ -1,31 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { ClipsRepository } from '../../domain/clips.repository';
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 import {
   ListRecentViewedClipsUseCase,
   RECENT_VIEWED_CLIPS_LIMIT,
 } from './list-recent-viewed-clips.usecase';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
 
 const createClipItem = (id: string) => ({
   id,

--- a/src/clips/application/usecases/record-clip-view.usecase.spec.ts
+++ b/src/clips/application/usecases/record-clip-view.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { ClipsRepository } from '../../domain/clips.repository';
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 import { RecordClipViewUseCase } from './record-clip-view.usecase';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
 
 describe('RecordClipViewUseCase', () => {
   it('내 클립이 아니면 NOT_FOUND 오류를 반환한다', async () => {

--- a/src/clips/application/usecases/unlike-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/unlike-clip.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { UnlikeClipUseCase } from './unlike-clip.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 
 describe('UnlikeClipUseCase', () => {
   it('클립이 없으면 NOT_FOUND 오류를 반환한다', async () => {

--- a/src/clips/application/usecases/update-clip.usecase.spec.ts
+++ b/src/clips/application/usecases/update-clip.usecase.spec.ts
@@ -1,31 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Logger } from '@nestjs/common';
 import { UpdateClipUseCase } from './update-clip.usecase';
-import { ClipsRepository } from '../../domain/clips.repository';
+import { createClipsRepositoryMock as createRepository } from '../../test-support/create-clips-repository-mock';
 import { ClipImageStoragePort } from 'src/shared/application/ports/clip-image-storage.port';
 import { MulterFile } from 'src/shared/types/multer-file.type';
-
-const createRepository = (): jest.Mocked<ClipsRepository> => ({
-  findPersonalFolderById: jest.fn(),
-  findClipByIdForUser: jest.fn(),
-  findClips: jest.fn(),
-  findRecentClips: jest.fn(),
-  hasTitleMatches: jest.fn(),
-  hasRecentTitleMatches: jest.fn(),
-  isClipMatchingQuery: jest.fn(),
-  isRecentCursorMatchingQuery: jest.fn(),
-  findRecentViewedClipIds: jest.fn(),
-  findClipsByIdsForUser: jest.fn(),
-  createClipView: jest.fn(),
-  isClipLikedByUser: jest.fn(),
-  createClipLike: jest.fn(),
-  deleteClipLike: jest.fn(),
-  createClip: jest.fn(),
-  updateClip: jest.fn(),
-  softDeleteClip: jest.fn(),
-  softDeleteClips: jest.fn(),
-  softDeleteAllClipsInFolder: jest.fn(),
-});
 
 const createImageStorage = (): jest.Mocked<ClipImageStoragePort> => ({
   uploadImage: jest.fn(),

--- a/src/clips/test-support/create-clips-repository-mock.ts
+++ b/src/clips/test-support/create-clips-repository-mock.ts
@@ -1,0 +1,23 @@
+import type { ClipsRepository } from '../domain/clips.repository';
+
+export const createClipsRepositoryMock = (): jest.Mocked<ClipsRepository> => ({
+  findPersonalFolderById: jest.fn(),
+  findClipByIdForUser: jest.fn(),
+  findClips: jest.fn(),
+  findRecentClips: jest.fn(),
+  findRecentViewedClipIds: jest.fn(),
+  findClipsByIdsForUser: jest.fn(),
+  hasTitleMatches: jest.fn(),
+  hasRecentTitleMatches: jest.fn(),
+  isClipMatchingQuery: jest.fn(),
+  isRecentCursorMatchingQuery: jest.fn(),
+  createClipView: jest.fn(),
+  isClipLikedByUser: jest.fn(),
+  createClipLike: jest.fn(),
+  deleteClipLike: jest.fn(),
+  createClip: jest.fn(),
+  updateClip: jest.fn(),
+  softDeleteClip: jest.fn(),
+  softDeleteClips: jest.fn(),
+  softDeleteAllClipsInFolder: jest.fn(),
+});

--- a/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder-tag.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { FoldersRepository } from '../../domain/folders.repository';
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 import { CreateFolderTagUseCase } from './create-folder-tag.usecase';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
 
 describe('CreateFolderTagUseCase', () => {
   it('폴더가 없으면 에러를 던진다', async () => {

--- a/src/folders/application/usecases/create-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/create-folder.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { CreateFolderUseCase } from './create-folder.usecase';
-import { FoldersRepository } from '../../domain/folders.repository';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 
 describe('CreateFolderUseCase', () => {
   it('워크스페이스가 없으면 생성 후 마지막 순서를 사용한다', async () => {

--- a/src/folders/application/usecases/delete-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/delete-folder-tag.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { FoldersRepository } from '../../domain/folders.repository';
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 import { DeleteFolderTagUseCase } from './delete-folder-tag.usecase';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
 
 describe('DeleteFolderTagUseCase', () => {
   it('폴더가 없으면 에러를 던진다', async () => {

--- a/src/folders/application/usecases/delete-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/delete-folder.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { DeleteFolderUseCase } from './delete-folder.usecase';
-import { FoldersRepository } from '../../domain/folders.repository';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 
 describe('DeleteFolderUseCase', () => {
   it('폴더가 없으면 에러를 던진다', async () => {

--- a/src/folders/application/usecases/get-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/get-folder.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { GetFolderUseCase } from './get-folder.usecase';
-import { FoldersRepository } from '../../domain/folders.repository';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 
 describe('GetFolderUseCase', () => {
   it('폴더가 없으면 에러를 던진다', async () => {

--- a/src/folders/application/usecases/list-folder-tags.usecase.spec.ts
+++ b/src/folders/application/usecases/list-folder-tags.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { FoldersRepository } from '../../domain/folders.repository';
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 import { ListFolderTagsUseCase } from './list-folder-tags.usecase';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
 
 describe('ListFolderTagsUseCase', () => {
   it('폴더가 없으면 에러를 던진다', async () => {

--- a/src/folders/application/usecases/list-folders.usecase.spec.ts
+++ b/src/folders/application/usecases/list-folders.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ListFoldersUseCase } from './list-folders.usecase';
-import { FoldersRepository } from '../../domain/folders.repository';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 
 describe('ListFoldersUseCase', () => {
   it('워크스페이스가 없으면 빈 배열을 반환한다', async () => {

--- a/src/folders/application/usecases/reorder-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/reorder-folder.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { ReorderFolderUseCase } from './reorder-folder.usecase';
-import { FoldersRepository } from '../../domain/folders.repository';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 
 describe('ReorderFolderUseCase', () => {
   it('afterId/beforeId가 모두 없으면 에러를 던진다', async () => {

--- a/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder-tag.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { FoldersRepository } from '../../domain/folders.repository';
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 import { UpdateFolderTagUseCase } from './update-folder-tag.usecase';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
 
 describe('UpdateFolderTagUseCase', () => {
   it('폴더가 없으면 에러를 던진다', async () => {

--- a/src/folders/application/usecases/update-folder.usecase.spec.ts
+++ b/src/folders/application/usecases/update-folder.usecase.spec.ts
@@ -1,28 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { UpdateFolderUseCase } from './update-folder.usecase';
-import { FoldersRepository } from '../../domain/folders.repository';
-
-const createRepository = (): jest.Mocked<FoldersRepository> => ({
-  findPersonalWorkspaceId: jest.fn(),
-  getOrCreatePersonalWorkspaceId: jest.fn(),
-  findFoldersByWorkspaceId: jest.fn(),
-  findPersonalFolderById: jest.fn(),
-  findFolderById: jest.fn(),
-  findFolderByIdInWorkspace: jest.fn(),
-  findTagsByFolderId: jest.fn(),
-  findTagByIdInFolder: jest.fn(),
-  findTagByNameInFolder: jest.fn(),
-  findLastFolderOrder: jest.fn(),
-  createFolder: jest.fn(),
-  createFolderTag: jest.fn(),
-  updateFolderName: jest.fn(),
-  updateFolderTagName: jest.fn(),
-  updateFolderOrder: jest.fn(),
-  deleteFolderTag: jest.fn(),
-  softDeleteFolder: jest.fn(),
-  findPreviousFolderOrder: jest.fn(),
-  findNextFolderOrder: jest.fn(),
-});
+import { createFoldersRepositoryMock as createRepository } from '../../test-support/create-folders-repository-mock';
 
 describe('UpdateFolderUseCase', () => {
   it('폴더가 없으면 에러를 던진다', async () => {

--- a/src/folders/test-support/create-folders-repository-mock.ts
+++ b/src/folders/test-support/create-folders-repository-mock.ts
@@ -1,0 +1,24 @@
+import type { FoldersRepository } from '../domain/folders.repository';
+
+export const createFoldersRepositoryMock =
+  (): jest.Mocked<FoldersRepository> => ({
+    findPersonalWorkspaceId: jest.fn(),
+    getOrCreatePersonalWorkspaceId: jest.fn(),
+    findFoldersByWorkspaceId: jest.fn(),
+    findPersonalFolderById: jest.fn(),
+    findFolderById: jest.fn(),
+    findFolderByIdInWorkspace: jest.fn(),
+    findTagsByFolderId: jest.fn(),
+    findTagByIdInFolder: jest.fn(),
+    findTagByNameInFolder: jest.fn(),
+    findLastFolderOrder: jest.fn(),
+    createFolder: jest.fn(),
+    createFolderTag: jest.fn(),
+    updateFolderName: jest.fn(),
+    updateFolderTagName: jest.fn(),
+    updateFolderOrder: jest.fn(),
+    deleteFolderTag: jest.fn(),
+    softDeleteFolder: jest.fn(),
+    findPreviousFolderOrder: jest.fn(),
+    findNextFolderOrder: jest.fn(),
+  });

--- a/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/confirm-billing-auth.usecase.spec.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { ConfirmBillingAuthUseCase } from './confirm-billing-auth.usecase';
 import { BillingPaymentGateway } from '../ports/billing-payment.gateway';
 import { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
-import { SubscriptionsRepository } from '../../domain/subscriptions.repository';
+import { createSubscriptionsRepositoryMock as createRepository } from '../../test-support/create-subscriptions-repository-mock';
 import {
   PaymentProvider,
   Subscription,
@@ -27,17 +27,6 @@ const createSubscription = (
   externalBillingKey: null,
   externalCustomerKey: 'customer-key',
   ...overrides,
-});
-
-const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
-  getOrCreatePersonalSubscription: jest.fn(),
-  findBillingMailRecipientByUserId: jest.fn(),
-  findBillingMailRecipientBySubscriptionId: jest.fn(),
-  updateSubscription: jest.fn(),
-  activateByPayment: jest.fn(),
-  recordPaymentFailure: jest.fn(),
-  claimAutoRenewalPayment: jest.fn(),
-  findDueAutoRenewalSubscriptions: jest.fn(),
 });
 
 const createGateway = (): jest.Mocked<BillingPaymentGateway> => ({

--- a/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/process-due-auto-renewals.usecase.spec.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { ProcessDueAutoRenewalsUseCase } from './process-due-auto-renewals.usecase';
 import { BillingPaymentGateway } from '../ports/billing-payment.gateway';
 import { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
-import { SubscriptionsRepository } from '../../domain/subscriptions.repository';
+import { createSubscriptionsRepositoryMock as createRepository } from '../../test-support/create-subscriptions-repository-mock';
 import {
   PaymentProvider,
   Subscription,
@@ -11,17 +11,6 @@ import {
   SubscriptionPlan,
   SubscriptionStatus,
 } from '../../domain/subscription.types';
-
-const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
-  getOrCreatePersonalSubscription: jest.fn(),
-  findBillingMailRecipientByUserId: jest.fn(),
-  findBillingMailRecipientBySubscriptionId: jest.fn(),
-  updateSubscription: jest.fn(),
-  activateByPayment: jest.fn(),
-  recordPaymentFailure: jest.fn(),
-  claimAutoRenewalPayment: jest.fn(),
-  findDueAutoRenewalSubscriptions: jest.fn(),
-});
 
 const createGateway = (): jest.Mocked<BillingPaymentGateway> => ({
   issueBillingKey: jest.fn(),

--- a/src/subscriptions/application/usecases/update-my-subscription.usecase.spec.ts
+++ b/src/subscriptions/application/usecases/update-my-subscription.usecase.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { UpdateMySubscriptionUseCase } from './update-my-subscription.usecase';
 import { SubscriptionPaymentMailPort } from '../ports/subscription-payment-mail.port';
-import { SubscriptionsRepository } from '../../domain/subscriptions.repository';
+import { createSubscriptionsRepositoryMock as createRepository } from '../../test-support/create-subscriptions-repository-mock';
 import {
   PaymentProvider,
   Subscription,
@@ -9,17 +9,6 @@ import {
   SubscriptionPlan,
   SubscriptionStatus,
 } from '../../domain/subscription.types';
-
-const createRepository = (): jest.Mocked<SubscriptionsRepository> => ({
-  getOrCreatePersonalSubscription: jest.fn(),
-  findBillingMailRecipientByUserId: jest.fn(),
-  findBillingMailRecipientBySubscriptionId: jest.fn(),
-  updateSubscription: jest.fn(),
-  activateByPayment: jest.fn(),
-  recordPaymentFailure: jest.fn(),
-  claimAutoRenewalPayment: jest.fn(),
-  findDueAutoRenewalSubscriptions: jest.fn(),
-});
 
 const createMailer = (): jest.Mocked<SubscriptionPaymentMailPort> => ({
   sendPaymentSuccess: jest.fn(),

--- a/src/subscriptions/test-support/create-subscriptions-repository-mock.ts
+++ b/src/subscriptions/test-support/create-subscriptions-repository-mock.ts
@@ -1,0 +1,13 @@
+import type { SubscriptionsRepository } from '../domain/subscriptions.repository';
+
+export const createSubscriptionsRepositoryMock =
+  (): jest.Mocked<SubscriptionsRepository> => ({
+    getOrCreatePersonalSubscription: jest.fn(),
+    findBillingMailRecipientByUserId: jest.fn(),
+    findBillingMailRecipientBySubscriptionId: jest.fn(),
+    updateSubscription: jest.fn(),
+    activateByPayment: jest.fn(),
+    recordPaymentFailure: jest.fn(),
+    claimAutoRenewalPayment: jest.fn(),
+    findDueAutoRenewalSubscriptions: jest.fn(),
+  });

--- a/src/trash/application/usecases/delete-all-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/delete-all-trash-items.usecase.spec.ts
@@ -1,21 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Logger } from '@nestjs/common';
 import { ClipImageStoragePort } from 'src/shared/application/ports/clip-image-storage.port';
-import { TrashRepository } from '../../domain/trash.repository';
+import { createTrashRepositoryMock as createRepository } from '../../test-support/create-trash-repository-mock';
 import { DeleteAllTrashItemsUseCase } from './delete-all-trash-items.usecase';
-
-const createRepository = (): jest.Mocked<TrashRepository> => ({
-  findDeletedItems: jest.fn(),
-  findDeletedClipsByIds: jest.fn(),
-  findDeletedClipById: jest.fn(),
-  restoreItems: jest.fn(),
-  hardDeleteItems: jest.fn(),
-  findDeletedFoldersByIds: jest.fn(),
-  findDeletedFolderById: jest.fn(),
-  hardDeleteExpiredFoldersWithClips: jest.fn(),
-  hardDeleteExpiredClips: jest.fn(),
-  hardDeleteAllTrashItemsForUser: jest.fn(),
-});
 
 const createImageStorage = (): jest.Mocked<ClipImageStoragePort> => ({
   uploadImage: jest.fn(),

--- a/src/trash/application/usecases/delete-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/delete-trash-items.usecase.spec.ts
@@ -1,21 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Logger } from '@nestjs/common';
 import { ClipImageStoragePort } from 'src/shared/application/ports/clip-image-storage.port';
-import { TrashRepository } from '../../domain/trash.repository';
+import { createTrashRepositoryMock as createRepository } from '../../test-support/create-trash-repository-mock';
 import { DeleteTrashItemsUseCase } from './delete-trash-items.usecase';
-
-const createRepository = (): jest.Mocked<TrashRepository> => ({
-  findDeletedItems: jest.fn(),
-  findDeletedClipsByIds: jest.fn(),
-  findDeletedClipById: jest.fn(),
-  restoreItems: jest.fn(),
-  hardDeleteItems: jest.fn(),
-  findDeletedFoldersByIds: jest.fn(),
-  findDeletedFolderById: jest.fn(),
-  hardDeleteExpiredFoldersWithClips: jest.fn(),
-  hardDeleteExpiredClips: jest.fn(),
-  hardDeleteAllTrashItemsForUser: jest.fn(),
-});
 
 const createImageStorage = (): jest.Mocked<ClipImageStoragePort> => ({
   uploadImage: jest.fn(),

--- a/src/trash/application/usecases/list-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/list-trash-items.usecase.spec.ts
@@ -1,19 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { TrashRepository } from '../../domain/trash.repository';
+import { createTrashRepositoryMock as createRepository } from '../../test-support/create-trash-repository-mock';
 import { ListTrashItemsUseCase } from './list-trash-items.usecase';
-
-const createRepository = (): jest.Mocked<TrashRepository> => ({
-  findDeletedItems: jest.fn(),
-  findDeletedClipsByIds: jest.fn(),
-  findDeletedClipById: jest.fn(),
-  restoreItems: jest.fn(),
-  hardDeleteItems: jest.fn(),
-  findDeletedFoldersByIds: jest.fn(),
-  findDeletedFolderById: jest.fn(),
-  hardDeleteExpiredFoldersWithClips: jest.fn(),
-  hardDeleteExpiredClips: jest.fn(),
-  hardDeleteAllTrashItemsForUser: jest.fn(),
-});
 
 describe('ListTrashItemsUseCase', () => {
   it('휴지통 클립과 폴더 목록 첫 페이지를 반환한다', async () => {

--- a/src/trash/application/usecases/purge-expired-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/purge-expired-trash-items.usecase.spec.ts
@@ -1,22 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { TrashRepository } from '../../domain/trash.repository';
+import { createTrashRepositoryMock as createRepository } from '../../test-support/create-trash-repository-mock';
 import { PurgeExpiredTrashItemsUseCase } from './purge-expired-trash-items.usecase';
 import { ClipImageStoragePort } from 'src/shared/application/ports/clip-image-storage.port';
-
-const createRepository = (): jest.Mocked<TrashRepository> => ({
-  findDeletedItems: jest.fn(),
-  findDeletedClipsByIds: jest.fn(),
-  findDeletedClipById: jest.fn(),
-  restoreItems: jest.fn(),
-  hardDeleteItems: jest.fn(),
-  findDeletedFoldersByIds: jest.fn(),
-  findDeletedFolderById: jest.fn(),
-  hardDeleteExpiredFoldersWithClips: jest.fn(),
-  hardDeleteExpiredClips: jest.fn(),
-  hardDeleteAllTrashItemsForUser: jest.fn(),
-});
 
 const createConfigService = (
   values: Record<string, string | undefined> = {},

--- a/src/trash/application/usecases/restore-trash-items.usecase.spec.ts
+++ b/src/trash/application/usecases/restore-trash-items.usecase.spec.ts
@@ -1,19 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { TrashRepository } from '../../domain/trash.repository';
+import { createTrashRepositoryMock as createRepository } from '../../test-support/create-trash-repository-mock';
 import { RestoreTrashItemsUseCase } from './restore-trash-items.usecase';
-
-const createRepository = (): jest.Mocked<TrashRepository> => ({
-  findDeletedItems: jest.fn(),
-  findDeletedClipsByIds: jest.fn(),
-  findDeletedClipById: jest.fn(),
-  restoreItems: jest.fn(),
-  hardDeleteItems: jest.fn(),
-  findDeletedFoldersByIds: jest.fn(),
-  findDeletedFolderById: jest.fn(),
-  hardDeleteExpiredFoldersWithClips: jest.fn(),
-  hardDeleteExpiredClips: jest.fn(),
-  hardDeleteAllTrashItemsForUser: jest.fn(),
-});
 
 describe('RestoreTrashItemsUseCase', () => {
   it('휴지통 클립 단건을 복구한다', async () => {

--- a/src/trash/test-support/create-trash-repository-mock.ts
+++ b/src/trash/test-support/create-trash-repository-mock.ts
@@ -1,0 +1,14 @@
+import type { TrashRepository } from '../domain/trash.repository';
+
+export const createTrashRepositoryMock = (): jest.Mocked<TrashRepository> => ({
+  findDeletedItems: jest.fn(),
+  findDeletedClipsByIds: jest.fn(),
+  findDeletedClipById: jest.fn(),
+  restoreItems: jest.fn(),
+  hardDeleteItems: jest.fn(),
+  findDeletedFoldersByIds: jest.fn(),
+  findDeletedFolderById: jest.fn(),
+  hardDeleteExpiredFoldersWithClips: jest.fn(),
+  hardDeleteExpiredClips: jest.fn(),
+  hardDeleteAllTrashItemsForUser: jest.fn(),
+});

--- a/src/users/application/usecases/delete-me.usecase.spec.ts
+++ b/src/users/application/usecases/delete-me.usecase.spec.ts
@@ -1,14 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { DeleteMeUseCase } from './delete-me.usecase';
-import { UsersRepository } from '../../domain/users.repository';
-
-const createRepository = (): jest.Mocked<UsersRepository> => ({
-  findUserById: jest.fn(),
-  findUserWithAuthAccounts: jest.fn(),
-  updateAuthAccountProfile: jest.fn(),
-  upsertUserSettings: jest.fn(),
-  deleteUserAndOwnedPersonalWorkspaces: jest.fn(),
-});
+import { createUsersRepositoryMock as createRepository } from '../../test-support/create-users-repository-mock';
 
 describe('DeleteMeUseCase', () => {
   it('사용자가 없으면 NOT_FOUND 에러를 던진다', async () => {

--- a/src/users/application/usecases/get-me.usecase.spec.ts
+++ b/src/users/application/usecases/get-me.usecase.spec.ts
@@ -1,13 +1,5 @@
 import { GetMeUseCase } from './get-me.usecase';
-import { UsersRepository } from '../../domain/users.repository';
-
-const createRepository = (): jest.Mocked<UsersRepository> => ({
-  findUserById: jest.fn(),
-  findUserWithAuthAccounts: jest.fn(),
-  updateAuthAccountProfile: jest.fn(),
-  upsertUserSettings: jest.fn(),
-  deleteUserAndOwnedPersonalWorkspaces: jest.fn(),
-});
+import { createUsersRepositoryMock as createRepository } from '../../test-support/create-users-repository-mock';
 
 describe('GetMeUseCase', () => {
   it('사용자가 없으면 NOT_FOUND 에러를 던진다', async () => {

--- a/src/users/application/usecases/get-user-settings.usecase.spec.ts
+++ b/src/users/application/usecases/get-user-settings.usecase.spec.ts
@@ -1,14 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { GetUserSettingsUseCase } from './get-user-settings.usecase';
-import { UsersRepository } from '../../domain/users.repository';
-
-const createRepository = (): jest.Mocked<UsersRepository> => ({
-  findUserById: jest.fn(),
-  findUserWithAuthAccounts: jest.fn(),
-  updateAuthAccountProfile: jest.fn(),
-  upsertUserSettings: jest.fn(),
-  deleteUserAndOwnedPersonalWorkspaces: jest.fn(),
-});
+import { createUsersRepositoryMock as createRepository } from '../../test-support/create-users-repository-mock';
 
 describe('GetUserSettingsUseCase', () => {
   it('사용자가 없으면 NOT_FOUND 에러를 던진다', async () => {

--- a/src/users/application/usecases/update-me.usecase.spec.ts
+++ b/src/users/application/usecases/update-me.usecase.spec.ts
@@ -1,14 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { UpdateMeUseCase } from './update-me.usecase';
-import { UsersRepository } from '../../domain/users.repository';
-
-const createRepository = (): jest.Mocked<UsersRepository> => ({
-  findUserById: jest.fn(),
-  findUserWithAuthAccounts: jest.fn(),
-  updateAuthAccountProfile: jest.fn(),
-  upsertUserSettings: jest.fn(),
-  deleteUserAndOwnedPersonalWorkspaces: jest.fn(),
-});
+import { createUsersRepositoryMock as createRepository } from '../../test-support/create-users-repository-mock';
 
 describe('UpdateMeUseCase', () => {
   it('사용자가 없으면 NOT_FOUND 에러를 던진다', async () => {

--- a/src/users/application/usecases/update-user-settings.usecase.spec.ts
+++ b/src/users/application/usecases/update-user-settings.usecase.spec.ts
@@ -1,14 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { UpdateUserSettingsUseCase } from './update-user-settings.usecase';
-import { UsersRepository } from '../../domain/users.repository';
-
-const createRepository = (): jest.Mocked<UsersRepository> => ({
-  findUserById: jest.fn(),
-  findUserWithAuthAccounts: jest.fn(),
-  updateAuthAccountProfile: jest.fn(),
-  upsertUserSettings: jest.fn(),
-  deleteUserAndOwnedPersonalWorkspaces: jest.fn(),
-});
+import { createUsersRepositoryMock as createRepository } from '../../test-support/create-users-repository-mock';
 
 describe('UpdateUserSettingsUseCase', () => {
   it('사용자가 없으면 NOT_FOUND 에러를 던진다', async () => {

--- a/src/users/test-support/create-users-repository-mock.ts
+++ b/src/users/test-support/create-users-repository-mock.ts
@@ -1,0 +1,9 @@
+import type { UsersRepository } from '../domain/users.repository';
+
+export const createUsersRepositoryMock = (): jest.Mocked<UsersRepository> => ({
+  findUserById: jest.fn(),
+  findUserWithAuthAccounts: jest.fn(),
+  updateAuthAccountProfile: jest.fn(),
+  upsertUserSettings: jest.fn(),
+  deleteUserAndOwnedPersonalWorkspaces: jest.fn(),
+});


### PR DESCRIPTION
## Description

도메인별 use-case 테스트에 중복 정의된 Repository mock을 각 feature domain의 `test-support` 팩토리로 공통화했습니다. 또한 도메인과 일치하는 커밋 스코프를 사용할 수 있도록 Git 워크플로 규칙을 확장했습니다.

## Type of change

- 내부 변경

## Linked tickets and other PRs

- Closes #134

## TODOs

- [x] 변경 사항 셀프 리뷰
- [x] 테스트 코드 정리 및 실행
- [ ] 수동 테스트 수행 (런타임 동작 변경 없음)

## Implementation

- Auth, Clips, Folders, Users, Subscriptions, Trash 도메인별 Repository mock 팩토리 추가
- 각 use-case 테스트에서 중복 mock 정의 제거
- `folder`, `subscriptions`, `trash` 커밋 스코프 허용 규칙 추가

## Testing done

- `pnpm test`: 50개 스위트, 213개 테스트 통과
- `pnpm exec eslint '{src,apps,libs,test}/**/*.ts'`: 통과
- `pnpm build`: 통과
- `pnpm test:e2e`: 미실행 (런타임 동작 변경 없음)

## Additional information

- Draft PR입니다.